### PR TITLE
Support for event calls at login

### DIFF
--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -4,7 +4,7 @@ import pluginId from './pluginId';
 import Initializer from './components/Initializer';
 import PluginIcon from './components/PluginIcon';
 
-const name = pluginPkg.strapi.name;
+const name = pluginPkg.strapi.displayName;
 
 export default {
   register(app) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-sso",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Plug-in for single sign-on with Strapi!",
   "strapi": {
     "displayName": "Single Sign On",

--- a/server/controllers/cognito.js
+++ b/server/controllers/cognito.js
@@ -33,7 +33,7 @@ async function cognitoSignIn(ctx) {
   const endpoint = OAUTH_ENDPOINT(config['COGNITO_OAUTH_DOMAIN'], config['COGNITO_OAUTH_REGION'])
   const url = `${endpoint}?client_id=${config['COGNITO_OAUTH_CLIENT_ID']}&redirect_uri=${redirectUri}&scope=${OAUTH_SCOPE}&response_type=${OAUTH_RESPONSE_TYPE}`
   ctx.set('Location', url)
-  return ctx.send({}, 301)
+  return ctx.send({}, 302)
 }
 
 async function cognitoSignInCallback(ctx) {

--- a/server/controllers/cognito.js
+++ b/server/controllers/cognito.js
@@ -97,6 +97,9 @@ async function cognitoSignInCallback(ctx) {
       // Trigger webhook
       await oauthService.triggerWebHook(activateUser)
     }
+    // Login Event Call
+    oauthService.triggerSignInSuccess(activateUser)
+
     const nonce = v4()
     const html = oauthService.renderSignUpSuccess(jwtToken, activateUser, nonce)
     ctx.set('Content-Security-Policy', `script-src 'nonce-${nonce}'`)

--- a/server/controllers/google.js
+++ b/server/controllers/google.js
@@ -102,6 +102,8 @@ async function googleSignInCallback(ctx) {
       // Trigger webhook
       await oauthService.triggerWebHook(activateUser)
     }
+    // Login Event Call
+    oauthService.triggerSignInSuccess(activateUser)
 
     // Client-side authentication persistence and redirection
     const nonce = v4()

--- a/server/controllers/google.js
+++ b/server/controllers/google.js
@@ -30,7 +30,7 @@ async function googleSignIn(ctx) {
   const redirectUri = encodeURIComponent(config['GOOGLE_OAUTH_REDIRECT_URI'])
   const url = `${OAUTH_ENDPOINT}?client_id=${config['GOOGLE_OAUTH_CLIENT_ID']}&redirect_uri=${redirectUri}&scope=${OAUTH_SCOPE}&response_type=${OAUTH_RESPONSE_TYPE}`
   ctx.set('Location', url)
-  return ctx.send({}, 301)
+  return ctx.send({}, 302)
 }
 
 /**

--- a/server/services/oauth.js
+++ b/server/services/oauth.js
@@ -57,6 +57,13 @@ module.exports = ({strapi}) => ({
       entry: sanitizedEntity,
     });
   },
+  triggerSignInSuccess(user) {
+    delete user['password']
+    strapi.eventHub.emit('admin.auth.success', {
+      user,
+      provider: 'strapi-plugin-sso'
+    });
+  },
   // Sign In Success
   renderSignUpSuccess(jwtToken, user, nonce) {
     return `


### PR DESCRIPTION
## Changes
- Changed status code for OAuth redirect to 302
    - 301, because there is a possibility that the cache will remain and not function properly.
- Changed the name displayed in the sidebar
- Event call on successful login is now supported
    - config/admin.js,  auth.events.onConnectionSuccess
    - Docs: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/required/admin-panel.html