### PR TITLE
feat: AzureAD provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ module.exports = ({env}) => ({
       COGNITO_OAUTH_DOMAIN: '[OAuth Domain created in AWS Cognito]',
       COGNITO_OAUTH_REDIRECT_URI: 'http://localhost:1337/strapi-plugin-sso/cognito/callback', //  // URI after successful login
       COGNITO_OAUTH_REGION: 'ap-northeast-1', // AWS Cognito Region 
+
+      // AzureAD
+      AZUREAD_OAUTH_REDIRECT_URI: 'http://localhost:1337/strapi-plugin-sso/azuread/callback',
+      AZUREAD_TENANT_ID: '[Tenant ID created in AzureAD]',
+      AZUREAD_OAUTH_CLIENT_ID: '[Client ID created in AzureAD]', // [Application (client) ID]
+      AZUREAD_OAUTH_CLIENT_SECRET: '[Client Secret created in AzureAD]',
+      AZUREAD_SCOPE: 'user.read', // https://learn.microsoft.com/en-us/graph/permissions-reference
     }
   }
 })
@@ -66,6 +73,8 @@ module.exports = ({env}) => ({
 
 [Cognito Single Sign On Setup](https://github.com/yasudacloud/strapi-plugin-sso/blob/main/docs/en/cognito/setup.md)
 
+[AzureAD Single Sign On Setup](https://github.com/yasudacloud/strapi-plugin-sso/blob/main/docs/en/azuread/setup.md)
+
 
 # Documentation(Japanese)
 [Description](https://github.com/yasudacloud/strapi-plugin-sso/blob/main/docs/README.md)
@@ -77,6 +86,8 @@ module.exports = ({env}) => ({
 [Cognito Single Sign On Setup](https://github.com/yasudacloud/strapi-plugin-sso/blob/main/docs/ja/cognito/setup.md)
 
 [Cognito Single Sign-On Specifications](https://github.com/yasudacloud/strapi-plugin-sso/blob/main/docs/ja/cognito/admin.md)
+
+TODO AzureAD Single Sign On Setup
 
 # Demo
 ![CognitoDemo](https://github.com/yasudacloud/strapi-plugin-sso/blob/main/docs/demo.gif?raw=true "DemoMovie")

--- a/docs/en/azuread/setup.md
+++ b/docs/en/azuread/setup.md
@@ -1,0 +1,31 @@
+# Single sign-on using AzureAD
+
+This document provides instructions for integrating AzureAD as a Single Sign-On (SSO) provider for this plugin. The process is similar to linking [Google accounts](../google/setup.md).
+
+## Setup
+
+1. Register your application in the Azure portal and configure it to use AzureAD.
+2. Create an OAuth2 client ID and secret.
+3. Set up the required environment variables and pass them in to `config/plugins.js`.
+
+## Available setting values
+
+| Key                         | Required | Default                                                  |
+| --------------------------- | -------- | -------------------------------------------------------- |
+| AZUREAD_OAUTH_CLIENT_ID     | ✅       | -                                                        |
+| AZUREAD_OAUTH_CLIENT_SECRET | ✅       | -                                                        |
+| AZUREAD_TENANT_ID           | ✅       | -                                                        |
+| AZUREAD_OAUTH_REDIRECT_URI  | -        | http://localhost:1337/strapi-plugin-sso/azuread/callback |
+| AZUREAD_SCOPE               | -        | user.read                                                |
+
+### Configuring environment variables
+
+Use the following environment variables to configure the AzureAD integration:
+
+1. `AZUREAD_OAUTH_CLIENT_ID`: The Application (client) ID created in AzureAD.
+2. `AZUREAD_OAUTH_CLIENT_SECRET`: The Client Secret created in AzureAD.
+3. `AZUREAD_TENANT_ID`: The Tenant ID created in AzureAD.
+4. `AZUREAD_OAUTH_REDIRECT_URI`: The callback URL used by AzureAD to redirect the user after authentication. Defaults to 'http://localhost:1337/strapi-plugin-sso/azuread/callback'.
+5. `AZUREAD_SCOPE`: The permissions your application requires from the user. Defaults to 'user.read'. More information on permissions can be found in the [Microsoft Graph permissions reference](https://docs.microsoft.com/en-us/graph/permissions-reference).
+
+Make sure to replace the placeholders with the actual values you obtained from AzureAD.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "strapi-plugin-sso",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "strapi-plugin-sso",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
-        "generate-password": "^1.7.0"
+        "generate-password": "^1.7.0",
+        "pkce-challenge": "^3.1.0"
       },
       "devDependencies": {
         "babel-eslint": "^10.1.0",
@@ -7586,6 +7587,11 @@
         "node": "*"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+    },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -14425,6 +14431,14 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-3.1.0.tgz",
+      "integrity": "sha512-bQ/0XPZZ7eX+cdAkd61uYWpfMhakH3NeteUF1R8GNa+LMqX8QFAkbCLqq+AYAns1/ueACBu/BMWhrlKGrdvGZg==",
+      "dependencies": {
+        "crypto-js": "^4.1.1"
       }
     },
     "node_modules/pkg-dir": {
@@ -25194,6 +25208,11 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -30492,6 +30511,14 @@
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
       "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
       "dev": true
+    },
+    "pkce-challenge": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-3.1.0.tgz",
+      "integrity": "sha512-bQ/0XPZZ7eX+cdAkd61uYWpfMhakH3NeteUF1R8GNa+LMqX8QFAkbCLqq+AYAns1/ueACBu/BMWhrlKGrdvGZg==",
+      "requires": {
+        "crypto-js": "^4.1.1"
+      }
     },
     "pkg-dir": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-sso",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Plug-in for single sign-on with Strapi!",
   "strapi": {
     "displayName": "Single Sign On",
@@ -24,7 +24,8 @@
     "@strapi/strapi": "^4.6.0"
   },
   "dependencies": {
-    "generate-password": "^1.7.0"
+    "generate-password": "^1.7.0",
+    "pkce-challenge": "^3.1.0"
   },
   "author": {
     "name": "yasudacloud",

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -8,6 +8,12 @@ module.exports = {
 
     COGNITO_OAUTH_REDIRECT_URI: 'http://localhost:1337/strapi-plugin-sso/cognito/callback',
     COGNITO_OAUTH_REGION: 'ap-northeast-1',
+
+    AZUREAD_OAUTH_REDIRECT_URI: 'http://localhost:1337/strapi-plugin-sso/azuread/callback',
+    AZUREAD_TENANT_ID: '',
+    AZUREAD_OAUTH_CLIENT_ID: '',
+    AZUREAD_OAUTH_CLIENT_SECRET: '',
+    AZUREAD_SCOPE: 'user.read',
   },
   validator() {
   },

--- a/server/controllers/azuread.js
+++ b/server/controllers/azuread.js
@@ -1,0 +1,134 @@
+"use strict";
+const axios = require("axios");
+const { v4 } = require("uuid");
+const { getService } = require("@strapi/admin/server/utils");
+const pkceChallenge = require("pkce-challenge").default;
+
+const configValidation = () => {
+  const config = strapi.config.get("plugin.strapi-plugin-sso");
+  if (
+    config["AZUREAD_OAUTH_CLIENT_ID"] &&
+    config["AZUREAD_OAUTH_CLIENT_SECRET"] &&
+    config["AZUREAD_TENANT_ID"]
+  ) {
+    return config;
+  }
+  throw new Error(
+    "AZUREAD_OAUTH_CLIENT_ID, AZUREAD_OAUTH_CLIENT_SECRET, and AZUREAD_TENANT_ID are required"
+  );
+};
+
+/**
+ * Common constants
+ */
+const OAUTH_ENDPOINT = (tenantId) =>
+  `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/authorize`;
+const OAUTH_TOKEN_ENDPOINT = (tenantId) =>
+  `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
+const OAUTH_USER_INFO_ENDPOINT = "https://graph.microsoft.com/oidc/userinfo";
+const OAUTH_GRANT_TYPE = "authorization_code";
+const OAUTH_RESPONSE_TYPE = "code";
+
+async function azureAdSignIn(ctx) {
+  const config = configValidation();
+  const redirectUri = encodeURIComponent(config["AZUREAD_OAUTH_REDIRECT_URI"]);
+  const endpoint = OAUTH_ENDPOINT(config["AZUREAD_TENANT_ID"]);
+
+  // Generate code verifier and code challenge
+  const { code_verifier: codeVerifier, code_challenge: codeChallenge } =
+    pkceChallenge();
+
+  // Store the code verifier in the session
+  ctx.session.codeVerifier = codeVerifier;
+
+  const url = `${endpoint}?client_id=${config["AZUREAD_OAUTH_CLIENT_ID"]}&redirect_uri=${redirectUri}&scope=${config["AZUREAD_SCOPE"]}&response_type=${OAUTH_RESPONSE_TYPE}&code_challenge=${codeChallenge}&code_challenge_method=S256`;
+  ctx.set("Location", url);
+  return ctx.send({}, 302);
+}
+
+async function azureAdSignInCallback(ctx) {
+  const config = configValidation();
+  const tokenService = getService("token");
+  const userService = getService("user");
+  const oauthService = strapi.plugin("strapi-plugin-sso").service("oauth");
+  const roleService = strapi.plugin("strapi-plugin-sso").service("role");
+
+  if (!ctx.query.code) {
+    return ctx.send(oauthService.renderSignUpError(`code Not Found`));
+  }
+
+  const params = new URLSearchParams();
+  params.append("code", ctx.query.code);
+  params.append("client_id", config["AZUREAD_OAUTH_CLIENT_ID"]);
+  params.append("client_secret", config["AZUREAD_OAUTH_CLIENT_SECRET"]);
+  params.append("redirect_uri", config["AZUREAD_OAUTH_REDIRECT_URI"]);
+  params.append("grant_type", OAUTH_GRANT_TYPE);
+
+  // Include the code verifier from the session
+  params.append("code_verifier", ctx.session.codeVerifier);
+
+  try {
+    const tokenEndpoint = OAUTH_TOKEN_ENDPOINT(config["AZUREAD_TENANT_ID"]);
+    const response = await axios.post(tokenEndpoint, params, {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+    });
+    const userResponse = await axios.get(OAUTH_USER_INFO_ENDPOINT, {
+      headers: {
+        Authorization: `Bearer ${response.data.access_token}`,
+      },
+    });
+
+    const dbUser = await userService.findOneByEmail(userResponse.data.email);
+    let activateUser;
+    let jwtToken;
+
+    if (dbUser) {
+      activateUser = dbUser;
+      jwtToken = await tokenService.createJwtToken(dbUser);
+    } else {
+      const azureAdRoles = await roleService.azureAdRoles();
+      const roles =
+        azureAdRoles && azureAdRoles["roles"]
+          ? azureAdRoles["roles"].map((role) => ({
+              id: role,
+            }))
+          : [];
+
+      const defaultLocale = oauthService.localeFindByHeader(
+        ctx.request.headers
+      );
+      activateUser = await oauthService.createUser(
+        userResponse.data.email,
+        userResponse.data.family_name,
+        userResponse.data.given_name,
+        defaultLocale,
+        roles
+      );
+      jwtToken = await tokenService.createJwtToken(activateUser);
+
+      // Trigger webhook
+      await oauthService.triggerWebHook(activateUser);
+    }
+    // Login Event Call
+    oauthService.triggerSignInSuccess(activateUser);
+
+    const nonce = v4();
+    const html = oauthService.renderSignUpSuccess(
+      jwtToken,
+      activateUser,
+      nonce
+    );
+    ctx.set("Content-Security-Policy", `script-src 'nonce-${nonce}'`);
+    ctx.send(html);
+  } catch (e) {
+    console.error(e.response.data);
+    ctx.send(oauthService.renderSignUpError(e.message));
+  }
+}
+
+module.exports = {
+  azureAdSignIn,
+  azureAdSignInCallback,
+};

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -1,11 +1,15 @@
-'use strict';
+"use strict";
 
-const google = require('./google')
-const cognito = require('./cognito')
-const role = require('./role')
+const google = require("./google");
+const cognito = require("./cognito");
+const azuread = require("./azuread");
+const role = require("./role");
+const login = require("./login");
 
 module.exports = {
   google,
   cognito,
-  role
+  azuread,
+  role,
+  login,
 };

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -4,12 +4,10 @@ const google = require("./google");
 const cognito = require("./cognito");
 const azuread = require("./azuread");
 const role = require("./role");
-const login = require("./login");
 
 module.exports = {
   google,
   cognito,
   azuread,
   role,
-  login,
 };

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -33,6 +33,22 @@ module.exports = [
   },
   {
     method: 'GET',
+    path: '/azuread',
+    handler: 'azuread.azureAdSignIn',
+    config: {
+      auth: false,
+    },
+  },
+  {
+    method: 'GET',
+    path: '/azuread/callback',
+    handler: 'azuread.azureAdSignInCallback',
+    config: {
+      auth: false,
+    },
+  },
+  {
+    method: 'GET',
     path: '/sso-roles',
     handler: 'role.find'
   },

--- a/server/services/role.js
+++ b/server/services/role.js
@@ -5,17 +5,19 @@ module.exports = ({strapi}) => ({
   SSO_TYPE_COGNITO: '2',
   SSO_TYPE_AZUREAD: "3",
   ssoRoles() {
-    return [{
-      'oauth_type': this.SSO_TYPE_GOOGLE,
-      name: 'Google'
-    }, {
-      'oauth_type': this.SSO_TYPE_COGNITO,
-      name: 'Cognito'
-    }],
-    {
-      oauth_type: this.SSO_TYPE_AZUREAD,
-      name: "AzureAD",
-    },
+    return [
+      {
+        'oauth_type': this.SSO_TYPE_GOOGLE,
+        name: 'Google'
+      }, {
+        'oauth_type': this.SSO_TYPE_COGNITO,
+        name: 'Cognito'
+      },
+      {
+       'oauth_type': this.SSO_TYPE_AZUREAD,
+        name: "AzureAD",
+      },
+    ];
   },
   async googleRoles() {
     return await strapi

--- a/server/services/role.js
+++ b/server/services/role.js
@@ -3,6 +3,7 @@
 module.exports = ({strapi}) => ({
   SSO_TYPE_GOOGLE: '1',
   SSO_TYPE_COGNITO: '2',
+  SSO_TYPE_AZUREAD: "3",
   ssoRoles() {
     return [{
       'oauth_type': this.SSO_TYPE_GOOGLE,
@@ -10,7 +11,11 @@ module.exports = ({strapi}) => ({
     }, {
       'oauth_type': this.SSO_TYPE_COGNITO,
       name: 'Cognito'
-    }]
+    }],
+    {
+      oauth_type: this.SSO_TYPE_AZUREAD,
+      name: "AzureAD",
+    },
   },
   async googleRoles() {
     return await strapi
@@ -25,6 +30,11 @@ module.exports = ({strapi}) => ({
       .findOne({
         'oauth_type': this.SSO_TYPE_COGNITO
       })
+  },
+  async azureAdRoles() {
+    return await strapi.query('plugin::strapi-plugin-sso.roles').findOne({
+      oauth_type: this.SSO_TYPE_AZUREAD,
+    });
   },
   async find() {
     return await strapi


### PR DESCRIPTION
This PR adds AzureAD as a Single Sign-On (SSO) provider the plugin, allowing users to authenticate using their AzureAD application registrations. The implementation follows the same shape as the current providers.

Key features:
- AzureAD OAuth2 client ID and secret configuration
- Tenant ID configuration
- Callback URL and scope configuration
- Updated documentation for AzureAD integration

Testing:
- I verified that this implementation worked for my company's AzureAD tenant + application.
- Please follow the updated documentation to set up AzureAD integration and ensure that users can successfully authenticate using their AzureAD credentials.