### PR TITLE
Increase random password entropy

### DIFF
--- a/server/services/oauth.js
+++ b/server/services/oauth.js
@@ -18,7 +18,7 @@ module.exports = ({strapi}) => ({
         firstname: firstname ? firstname : 'unset',
         lastname: lastname ? lastname : 'user',
         password: generator.generate({
-          length: 12,
+          length: 43, // 256 bits (https://en.wikipedia.org/wiki/Password_strength#Random_passwords)
           numbers: true,
           lowercase: true,
           uppercase: true,


### PR DESCRIPTION
The current code creates a random password that is only 12 characters long. This pull request increases the password length to 43 characters which gives 256-bit entropy.