### PR TITLE
Lowercase email address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strapi-plugin-sso",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "strapi-plugin-sso",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "generate-password": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-sso",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Plug-in for single sign-on with Strapi!",
   "strapi": {
     "displayName": "Single Sign On",

--- a/server/services/oauth.js
+++ b/server/services/oauth.js
@@ -4,15 +4,24 @@ const generator = require('generate-password');
 
 module.exports = ({strapi}) => ({
   async createUser(email, lastname, firstname, locale, roles = []) {
-    const createdUser = await getService('user').create({
+    // If the email address contains uppercase letters, convert it to lowercase and retrieve it from the DB. If not, register a new email address with a lower-case email address.
+    const userService = getService('user')
+    if (/[A-Z]/.test(email)) {
+      const dbUser = await userService.findOneByEmail(email.toLocaleLowerCase())
+      if (dbUser) {
+        return dbUser
+      }
+    }
+
+    const createdUser = await userService.create({
       firstname: firstname ? firstname : 'unset',
       lastname: lastname ? lastname : '',
-      email,
+      email: email.toLocaleLowerCase(),
       roles,
       preferedLanguage: locale,
     });
 
-    return await getService('user').register({
+    return await userService.register({
       registrationToken: createdUser.registrationToken,
       userInfo: {
         firstname: firstname ? firstname : 'unset',


### PR DESCRIPTION
This PR changes the registration process to save new email addresses in lowercase. However, for compatibility, email addresses previously registered in uppercase can still be used.

Registered in upper case -> Log in with uppercase letters
Registered in lower case -> Log in with lower letters
Unregistered upper case -> Log in with lower letters
Unregistered lowercase -> Log in with lower letters