### PR TITLE
feat(deps): update pkce-challenge to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "generate-password": "^1.7.0",
-        "pkce-challenge": "^3.1.0"
+        "pkce-challenge": "^4.0.1"
       },
       "devDependencies": {
         "babel-eslint": "^10.1.0",
@@ -7587,11 +7587,6 @@
         "node": "*"
       }
     },
-    "node_modules/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
-    },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -14434,11 +14429,11 @@
       }
     },
     "node_modules/pkce-challenge": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-3.1.0.tgz",
-      "integrity": "sha512-bQ/0XPZZ7eX+cdAkd61uYWpfMhakH3NeteUF1R8GNa+LMqX8QFAkbCLqq+AYAns1/ueACBu/BMWhrlKGrdvGZg==",
-      "dependencies": {
-        "crypto-js": "^4.1.1"
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.0.1.tgz",
+      "integrity": "sha512-WGmtS1stcStsvRwNXix3iR1ujFcDaJR+sEODRa2ZFruT0lM4lhPAFTL5SUpqD5vTJdRlgtuMQhcp1kIEJx4LUw==",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -25208,11 +25203,6 @@
         "randomfill": "^1.0.3"
       }
     },
-    "crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
-    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -30513,12 +30503,9 @@
       "dev": true
     },
     "pkce-challenge": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-3.1.0.tgz",
-      "integrity": "sha512-bQ/0XPZZ7eX+cdAkd61uYWpfMhakH3NeteUF1R8GNa+LMqX8QFAkbCLqq+AYAns1/ueACBu/BMWhrlKGrdvGZg==",
-      "requires": {
-        "crypto-js": "^4.1.1"
-      }
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.0.1.tgz",
+      "integrity": "sha512-WGmtS1stcStsvRwNXix3iR1ujFcDaJR+sEODRa2ZFruT0lM4lhPAFTL5SUpqD5vTJdRlgtuMQhcp1kIEJx4LUw=="
     },
     "pkg-dir": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "generate-password": "^1.7.0",
-    "pkce-challenge": "^3.1.0"
+    "pkce-challenge": "^4.0.1"
   },
   "author": {
     "name": "yasudacloud",


### PR DESCRIPTION
This PR update the pkce-challenge dependency to v4, which ships without unsecure and unmaintened crypto-js library, see https://github.com/crouchcd/pkce-challenge/issues/9 & https://github.com/advisories/GHSA-xwcq-pm8m-c4vf