### PR TITLE
#45 webhook support for older versions of Strapi

### DIFF
--- a/server/services/oauth.js
+++ b/server/services/oauth.js
@@ -54,7 +54,14 @@ module.exports = ({ strapi }) => ({
     }
   },
   async triggerWebHook(user) {
-    const { ENTRY_CREATE } = strapi.webhookStore.allowedEvents;
+    let ENTRY_CREATE
+    if (strapi.webhookStore && strapi.webhookStore.allowedEvents) {
+      ENTRY_CREATE = strapi.webhookStore.allowedEvents.get('ENTRY_CREATE');
+    } else {
+      // deprecated
+      ENTRY_CREATE = strapiUtils.webhook.webhookEvents.ENTRY_CREATE;
+    }
+
     const modelDef = strapi.getModel("admin::user");
     const sanitizedEntity = await strapiUtils.sanitize.sanitizers.defaultSanitizeOutput(modelDef, user);
     strapi.eventHub.emit(ENTRY_CREATE, {


### PR DESCRIPTION
I changed the previous PR to not use the deprecated function of webhook so that it would work with older Strapi versions.

In addition, a bug in the new webhook call was not working correctly and has been fixed.