### PR TITLE
Set the plugin as ready on register

### DIFF
--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -23,7 +23,6 @@ export default {
     app.registerPlugin({
       id: pluginId,
       initializer: Initializer,
-      isReady: false,
       name,
     });
   },


### PR DESCRIPTION
Hello,
this fixes an issue with the current v5 implementation where the plugin is marked as not ready on registration, leading to the admin panel not always being able to load successfully.