### PR TITLE
fix: update role service call from googleRoles to cognitoRoles

### DIFF
--- a/server/controllers/cognito.js
+++ b/server/controllers/cognito.js
@@ -81,7 +81,7 @@ async function cognitoSignInCallback(ctx) {
       activateUser = dbUser;
       jwtToken = await tokenService.createJwtToken(dbUser)
     } else {
-      const cognitoRoles = await roleService.googleRoles()
+      const cognitoRoles = await roleService.cognitoRoles()
       const roles = cognitoRoles && cognitoRoles['roles'] ? cognitoRoles['roles'].map(role => ({
         id: role
       })) : []


### PR DESCRIPTION
Thank you for developing such an awesome plugin.
I have fixed an issue with the default role when signing in via Cognito.

## Expected Behavior
The default role specified in the Cognito section of the settings screen should be applied.

## Actual Behavior
The default role specified in the Google section of the settings screen is applied.