### PR TITLE
Allow signed-in users to retrieve their JWT

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -75,6 +75,14 @@ export default [
   },
   {
     method: 'GET',
+    path: '/oidc/jwt',
+    handler: 'oidc.oidcSignInCallback',
+    config: {
+      auth: false,
+    },
+  },
+  {
+    method: 'GET',
     path: '/whitelist',
     handler: 'whitelist.info',
   },

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -76,7 +76,7 @@ export default [
   {
     method: 'GET',
     path: '/oidc/jwt',
-    handler: 'oidc.oidcSignInCallback',
+    handler: 'oidc.oidcGetJwt',
     config: {
       auth: false,
     },


### PR DESCRIPTION
This allows users to get their Strapi JWT by providing their OIDC access token.

### Example use case

User wants to access some private data as stored in a Strapi entity. Here is the expected workflow:

1. the user starts the authentication flow on the website (via OIDC)
2. upon completion, the frontend GETs the Strapi JWT via the `/oidc/jwt` route
3. the frontend performs a request to the Strapi instance to get some user-scoped resource
4. the Strapi instance authenticates the request by checking the provided JWT

To me, this looks like a fairly common use case so I'm wondering if users have achieved this feature by other means. I have also considered using an auth provider (such as Authelia) to provide authorization for each protected Strapi resource, however that was unfeasible since there is no direct mapping between the ID of the protected resource in Strapi and the data Authelia has available.