### PR TITLE
Move settings section

### DIFF
--- a/admin/src/components/AlertMessage/index.jsx
+++ b/admin/src/components/AlertMessage/index.jsx
@@ -32,7 +32,7 @@ export function SuccessAlertMessage({onClose}) {
   )
 }
 
-export function ErrorAlertMessage() {
+export function ErrorAlertMessage({onClose}) {
   const {formatMessage} = useIntl();
   return (
     <AlertMessage>

--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -2,24 +2,11 @@ import { getTranslation } from './utils/getTranslation';
 import pluginPkg from '../../package.json';
 import pluginId from './pluginId';
 import Initializer from './components/Initializer';
-import PluginIcon from './components/PluginIcon';
 
 const name = pluginPkg.strapi.displayName;
 
 export default {
   register(app) {
-    app.addMenuLink({
-      to: `/plugins/${pluginId}`,
-      icon: PluginIcon,
-      intlLabel: {
-        id: `${pluginId}.plugin.name`,
-        defaultMessage: name,
-      },
-      Component: async () => {
-        return await import('./pages/App');
-      },
-      permissions: [{ action: 'plugin::strapi-plugin-sso.read', subject: null }]
-    });
     app.registerPlugin({
       id: pluginId,
       initializer: Initializer,
@@ -27,7 +14,29 @@ export default {
     });
   },
 
-  bootstrap(app) {},
+  bootstrap({ addSettingsLink }) {
+    addSettingsLink(
+      {
+        id: pluginId,
+        intlLabel: {
+          id: `${pluginId}.plugin.name`,
+          defaultMessage: 'Single Sign On',
+        },
+        links: [
+          {
+            intlLabel: {
+              id: `${pluginId}.settings.configuration`,
+              defaultMessage: 'Configuration',
+            },
+            id: `${pluginId}-configuration`,
+            to: `/settings/${pluginId}`,
+            Component: () => import('./pages/HomePage'),
+            permissions: [{ action: 'plugin::strapi-plugin-sso.read', subject: null }],
+          },
+        ],
+      }
+    );
+  },
   async registerTrads({ locales }) {
     const importedTrads = await Promise.all(
       locales.map(locale => {

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -1,8 +1,9 @@
 export default async ({strapi}) => {
   const actions = [
     {
-      section: 'plugins',
-      displayName: 'Read',
+      section: 'settings',
+      category: 'single sign on',
+      displayName: 'Access the SSO settings page',
       uid: 'read',
       pluginName: 'strapi-plugin-sso',
     },

--- a/server/controllers/role.js
+++ b/server/controllers/role.js
@@ -17,7 +17,7 @@ async function update(ctx) {
     const {roles} = ctx.request.body
     const roleService = strapi.plugin('strapi-plugin-sso').service('role')
     await roleService.update(roles)
-    ctx.send({}, 204)
+    ctx.send({ ok: true })
   } catch (e) {
     console.log(e)
     ctx.send({}, 400)


### PR DESCRIPTION
A little quality of life improvement for this plugin.

It moves the settings page to Strapi settings, freeing up some space on the left menu. 

Also moved the plugin permission configuration inside the settings section, and gave a more meaningful name to the flag. I haven't changed the `uid`, so current permissions should be preserved.