### PR TITLE
fix: normalise email to lowercase in whitelist service

### DIFF
--- a/dist/_chunks/en-AsM8uCFB.mjs
+++ b/dist/_chunks/en-AsM8uCFB.mjs
@@ -1,0 +1,23 @@
+const en = {
+  "page.title": "Default role setting at first login",
+  "page.notes": "This will not be reflected for already registered users.",
+  "page.save": "Save",
+  "page.save.success": "Updated settings",
+  "page.save.error": "Update failed.",
+  "page.cancel": "Cancel",
+  "page.ok": "OK",
+  "tab.roles": "Roles",
+  "tab.whitelist": "Whitelist",
+  "tab.whitelist.error.unique": "Already registered email address.",
+  "tab.whitelist.enabled": "Whitelist is currently enabled.",
+  "tab.whitelist.disabled": "Whitelist is currently disabled.",
+  "tab.whitelist.description": "Only the following email addresses are allowed to authenticate with SSO.",
+  "tab.whitelist.table.no": "No",
+  "tab.whitelist.table.email": "Email",
+  "tab.whitelist.table.created": "Created At",
+  "tab.whitelist.delete.title": "Confirmation",
+  "tab.whitelist.delete.description": "Are you sure you want to delete this?"
+};
+export {
+  en as default
+};

--- a/dist/_chunks/en-BbQ9XzfO.js
+++ b/dist/_chunks/en-BbQ9XzfO.js
@@ -1,0 +1,23 @@
+"use strict";
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const en = {
+  "page.title": "Default role setting at first login",
+  "page.notes": "This will not be reflected for already registered users.",
+  "page.save": "Save",
+  "page.save.success": "Updated settings",
+  "page.save.error": "Update failed.",
+  "page.cancel": "Cancel",
+  "page.ok": "OK",
+  "tab.roles": "Roles",
+  "tab.whitelist": "Whitelist",
+  "tab.whitelist.error.unique": "Already registered email address.",
+  "tab.whitelist.enabled": "Whitelist is currently enabled.",
+  "tab.whitelist.disabled": "Whitelist is currently disabled.",
+  "tab.whitelist.description": "Only the following email addresses are allowed to authenticate with SSO.",
+  "tab.whitelist.table.no": "No",
+  "tab.whitelist.table.email": "Email",
+  "tab.whitelist.table.created": "Created At",
+  "tab.whitelist.delete.title": "Confirmation",
+  "tab.whitelist.delete.description": "Are you sure you want to delete this?"
+};
+exports.default = en;

--- a/dist/_chunks/fr-C8Qw4iPZ.js
+++ b/dist/_chunks/fr-C8Qw4iPZ.js
@@ -1,0 +1,4 @@
+"use strict";
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const fr = {};
+exports.default = fr;

--- a/dist/_chunks/fr-hkSxFuzl.mjs
+++ b/dist/_chunks/fr-hkSxFuzl.mjs
@@ -1,0 +1,4 @@
+const fr = {};
+export {
+  fr as default
+};

--- a/dist/_chunks/index-6i2aMsbo.js
+++ b/dist/_chunks/index-6i2aMsbo.js
@@ -1,0 +1,372 @@
+"use strict";
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const jsxRuntime = require("react/jsx-runtime");
+const react = require("react");
+const reactRouterDom = require("react-router-dom");
+const admin = require("@strapi/strapi/admin");
+const designSystem = require("@strapi/design-system");
+const reactIntl = require("react-intl");
+const index = require("./index-BFqpFqpc.js");
+const styled = require("styled-components");
+const icons = require("@strapi/icons");
+const _interopDefault = (e) => e && e.__esModule ? e : { default: e };
+const styled__default = /* @__PURE__ */ _interopDefault(styled);
+const getTrad = (id) => `${index.pluginId}.${id}`;
+const ButtonWrapper = styled__default.default.div`
+    margin: 10px 0 0 0;
+
+    & button {
+        margin: 0 0 0 auto;
+    }
+`;
+const Description = styled__default.default.p`
+    font-size: 16px;
+    margin: 20px 0;
+`;
+function Role({ ssoRoles, roles, onSaveRole, onChangeRoleCheck }) {
+  const { formatMessage } = reactIntl.useIntl();
+  return /* @__PURE__ */ jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [
+    /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Table, { colCount: roles.length + 1, rowCount: ssoRoles.length, children: [
+      /* @__PURE__ */ jsxRuntime.jsx(designSystem.Thead, { children: /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Tr, { children: [
+        /* @__PURE__ */ jsxRuntime.jsx(designSystem.Th, { children: /* @__PURE__ */ jsxRuntime.jsx(designSystem.Checkbox, { style: { display: "none" } }) }),
+        roles.map((role) => /* @__PURE__ */ jsxRuntime.jsx(designSystem.Th, { children: role["name"] }, role["id"]))
+      ] }) }),
+      /* @__PURE__ */ jsxRuntime.jsx(designSystem.Tbody, { children: ssoRoles.map((ssoRole) => /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Tr, { children: [
+        /* @__PURE__ */ jsxRuntime.jsx(designSystem.Td, { children: ssoRole["name"] }),
+        roles.map((role) => /* @__PURE__ */ jsxRuntime.jsx(designSystem.Th, { children: /* @__PURE__ */ jsxRuntime.jsx(
+          designSystem.Checkbox,
+          {
+            checked: ssoRole["role"] && ssoRole["role"].includes(role["id"]),
+            onCheckedChange: (value) => onChangeRoleCheck(value, ssoRole["oauth_type"], role["id"]),
+            children: ""
+          }
+        ) }, role["id"]))
+      ] }, ssoRole["oauth_type"])) })
+    ] }),
+    /* @__PURE__ */ jsxRuntime.jsx(Description, { children: formatMessage({
+      id: getTrad("page.notes"),
+      defaultMessage: "This will not be reflected for already registered users."
+    }) }),
+    /* @__PURE__ */ jsxRuntime.jsx(ButtonWrapper, { children: /* @__PURE__ */ jsxRuntime.jsx(designSystem.Button, { variant: "default", onClick: onSaveRole, children: formatMessage({
+      id: getTrad("page.save"),
+      defaultMessage: "Save"
+    }) }) })
+  ] });
+}
+const LocalizedDate = ({ date }) => {
+  const userLocale = navigator.language || "en-US";
+  return new Intl.DateTimeFormat(userLocale, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit"
+  }).format(new Date(date));
+};
+function Whitelist({ users, useWhitelist, loading, onSave, onDelete }) {
+  const [email, setEmail] = react.useState("");
+  const { formatMessage } = reactIntl.useIntl();
+  const onSaveEmail = react.useCallback(async () => {
+    const emailText = email.trim();
+    if (users.some((user) => user.email === emailText)) {
+      alert(
+        formatMessage({
+          id: getTrad("tab.whitelist.error.unique"),
+          defaultMessage: "Already registered email address."
+        })
+      );
+    } else {
+      await onSave(emailText);
+      setEmail("");
+    }
+  }, [email, users]);
+  const isValidEmail = react.useCallback(() => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  }, [email]);
+  return /* @__PURE__ */ jsxRuntime.jsx(jsxRuntime.Fragment, { children: /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Box, { padding: 4, children: [
+    /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Typography, { tag: "div", children: [
+      useWhitelist && /* @__PURE__ */ jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [
+        /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Flex, { children: [
+          /* @__PURE__ */ jsxRuntime.jsx(icons.Check, { color: "green" }),
+          " ",
+          formatMessage({
+            id: getTrad("tab.whitelist.enabled"),
+            defaultMessage: "Whitelist is currently enabled."
+          }),
+          /* @__PURE__ */ jsxRuntime.jsx("br", {})
+        ] }),
+        formatMessage({
+          id: getTrad("tab.whitelist.description"),
+          defaultMessage: "Only the following email addresses are allowed to authenticate with SSO."
+        })
+      ] }),
+      !useWhitelist && /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Flex, { children: [
+        /* @__PURE__ */ jsxRuntime.jsx(icons.WarningCircle, { color: "#dd0000" }),
+        " ",
+        formatMessage({
+          id: getTrad("tab.whitelist.disabled"),
+          defaultMessage: "Whitelist is currently disabled."
+        })
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntime.jsx(designSystem.Grid.Root, { tag: "fieldset", gap: 4, padding: "0px", gridCols: 2, borderWidth: 0, marginTop: 5, marginBottom: 5, children: /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Grid.Item, { xs: 1, children: [
+      /* @__PURE__ */ jsxRuntime.jsx(designSystem.Field.Root, { children: /* @__PURE__ */ jsxRuntime.jsx(
+        designSystem.Field.Input,
+        {
+          type: "email",
+          disabled: loading,
+          value: email,
+          hasError: email && !isValidEmail(),
+          onChange: (e) => setEmail(e.currentTarget.value)
+        }
+      ) }),
+      " ",
+      /* @__PURE__ */ jsxRuntime.jsx(
+        designSystem.Button,
+        {
+          startIcon: /* @__PURE__ */ jsxRuntime.jsx(icons.Plus, {}),
+          disabled: loading || email.trim() === "" || !isValidEmail(),
+          loading,
+          onClick: onSaveEmail,
+          children: formatMessage({
+            id: getTrad("page.save"),
+            defaultMessage: "Save"
+          })
+        }
+      )
+    ] }) }),
+    /* @__PURE__ */ jsxRuntime.jsx(designSystem.Divider, {}),
+    /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Table, { colCount: 4, rowCount: users.length, children: [
+      /* @__PURE__ */ jsxRuntime.jsx(designSystem.Thead, { children: /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Tr, { children: [
+        /* @__PURE__ */ jsxRuntime.jsx(designSystem.Th, { children: formatMessage({
+          id: getTrad("tab.whitelist.table.no"),
+          defaultMessage: "No"
+        }) }),
+        /* @__PURE__ */ jsxRuntime.jsx(designSystem.Th, { children: formatMessage({
+          id: getTrad("tab.whitelist.table.email"),
+          defaultMessage: "Email"
+        }) }),
+        /* @__PURE__ */ jsxRuntime.jsx(designSystem.Th, { children: formatMessage({
+          id: getTrad("tab.whitelist.table.created"),
+          defaultMessage: "Created At"
+        }) }),
+        /* @__PURE__ */ jsxRuntime.jsx(designSystem.Th, { children: " " })
+      ] }) }),
+      /* @__PURE__ */ jsxRuntime.jsx(designSystem.Tbody, { children: users.map((user) => /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Tr, { children: [
+        /* @__PURE__ */ jsxRuntime.jsx(designSystem.Td, { children: user.id }),
+        /* @__PURE__ */ jsxRuntime.jsx(designSystem.Td, { children: user.email }),
+        /* @__PURE__ */ jsxRuntime.jsx(designSystem.Td, { children: /* @__PURE__ */ jsxRuntime.jsx(LocalizedDate, { date: user.createdAt }) }),
+        /* @__PURE__ */ jsxRuntime.jsx(designSystem.Td, { children: /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Dialog.Root, { children: [
+          /* @__PURE__ */ jsxRuntime.jsx(designSystem.Dialog.Trigger, { children: /* @__PURE__ */ jsxRuntime.jsx(designSystem.IconButton, { label: "Delete", withTooltip: false, children: /* @__PURE__ */ jsxRuntime.jsx(icons.Trash, {}) }) }),
+          /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Dialog.Content, { children: [
+            /* @__PURE__ */ jsxRuntime.jsx(designSystem.Dialog.Header, { children: formatMessage({
+              id: getTrad("tab.whitelist.delete.title"),
+              defaultMessage: "Confirmation"
+            }) }),
+            /* @__PURE__ */ jsxRuntime.jsx(designSystem.Dialog.Body, { icon: /* @__PURE__ */ jsxRuntime.jsx(icons.WarningCircle, { fill: "danger600" }), children: /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Typography, { variant: "delta", children: [
+              formatMessage({
+                id: getTrad("tab.whitelist.delete.description"),
+                defaultMessage: "Are you sure you want to delete this?"
+              }),
+              /* @__PURE__ */ jsxRuntime.jsx("br", {}),
+              user.email
+            ] }) }),
+            /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Dialog.Footer, { children: [
+              /* @__PURE__ */ jsxRuntime.jsx(designSystem.Dialog.Cancel, { children: /* @__PURE__ */ jsxRuntime.jsx(designSystem.Button, { fullWidth: true, variant: "tertiary", children: formatMessage({
+                id: getTrad("page.cancel"),
+                defaultMessage: "Cancel"
+              }) }) }),
+              /* @__PURE__ */ jsxRuntime.jsx(designSystem.Dialog.Action, { children: /* @__PURE__ */ jsxRuntime.jsx(designSystem.Button, { fullWidth: true, variant: "danger-light", onClick: () => onDelete(user.id), children: formatMessage({
+                id: getTrad("page.ok"),
+                defaultMessage: "OK"
+              }) }) })
+            ] })
+          ] })
+        ] }) })
+      ] }, user.id)) })
+    ] })
+  ] }) });
+}
+const AlertMessage = styled__default.default.div`
+    margin-left: -250px;
+    position: fixed;
+    left: 50%;
+    top: 2.875rem;
+    z-index: 10;
+    width: 31.25rem;
+`;
+function SuccessAlertMessage({ onClose: onClose2 }) {
+  const { formatMessage } = reactIntl.useIntl();
+  return /* @__PURE__ */ jsxRuntime.jsx(AlertMessage, { children: /* @__PURE__ */ jsxRuntime.jsx(
+    designSystem.Alert,
+    {
+      title: "Success",
+      variant: "success",
+      closeLabel: "",
+      onClose: onClose2,
+      children: formatMessage({
+        id: getTrad("page.save.success"),
+        defaultMessage: "Updated settings"
+      })
+    }
+  ) });
+}
+function ErrorAlertMessage() {
+  const { formatMessage } = reactIntl.useIntl();
+  return /* @__PURE__ */ jsxRuntime.jsx(AlertMessage, { children: /* @__PURE__ */ jsxRuntime.jsx(
+    designSystem.Alert,
+    {
+      title: "Error",
+      variant: "danger",
+      closeLabel: "",
+      onClose,
+      children: formatMessage({
+        id: getTrad("page.save.error"),
+        defaultMessage: "Update failed."
+      })
+    }
+  ) });
+}
+const HomePage = () => {
+  const { formatMessage } = reactIntl.useIntl();
+  const [loading, setLoading] = react.useState(false);
+  const [ssoRoles, setSSORoles] = react.useState([]);
+  const [roles, setRoles] = react.useState([]);
+  const [useWhitelist, setUseWhitelist] = react.useState(false);
+  const [users, setUsers] = react.useState([]);
+  const [showSuccess, setSuccess] = react.useState(false);
+  const [showError, setError] = react.useState(false);
+  const { get, put, post, del } = admin.useFetchClient();
+  react.useEffect(() => {
+    get(`/strapi-plugin-sso/sso-roles`).then((response) => {
+      setSSORoles(response.data);
+    });
+    get(`/admin/roles`).then((response) => {
+      setRoles(response.data.data);
+    });
+    get("/strapi-plugin-sso/whitelist").then((response) => {
+      setUsers(response.data.whitelistUsers);
+      setUseWhitelist(response.data.useWhitelist);
+    });
+  }, [setSSORoles, setRoles]);
+  const onChangeRoleCheck = (value, ssoId, role) => {
+    for (const ssoRole of ssoRoles) {
+      if (ssoRole["oauth_type"] === ssoId) {
+        if (ssoRole["role"]) {
+          if (value) {
+            ssoRole["role"].push(role);
+          } else {
+            ssoRole["role"] = ssoRole["role"].filter((selectRole) => selectRole !== role);
+          }
+        } else {
+          ssoRole["role"] = [role];
+        }
+      }
+    }
+    setSSORoles(ssoRoles.slice());
+  };
+  const onSaveRole = async () => {
+    try {
+      await put("/strapi-plugin-sso/sso-roles", {
+        roles: ssoRoles.map((role) => ({
+          "oauth_type": role["oauth_type"],
+          role: role["role"]
+        }))
+      });
+      setSuccess(true);
+      setTimeout(() => {
+        setSuccess(false);
+      }, 3e3);
+    } catch (e) {
+      console.error(e);
+      setError(true);
+      setTimeout(() => {
+        setError(false);
+      }, 3e3);
+    }
+  };
+  const onRegisterWhitelist = async (email) => {
+    setLoading(true);
+    post("/strapi-plugin-sso/whitelist", {
+      email
+    }).then((response) => {
+      get("/strapi-plugin-sso/whitelist").then((response2) => {
+        setUsers(response2.data.whitelistUsers);
+        setUseWhitelist(response2.data.useWhitelist);
+      });
+      setLoading(false);
+      setSuccess(true);
+      setTimeout(() => {
+        setSuccess(false);
+      }, 3e3);
+    });
+  };
+  const onDeleteWhitelist = async (id) => {
+    setLoading(true);
+    del(`/strapi-plugin-sso/whitelist/${id}`).then((response) => {
+      get("/strapi-plugin-sso/whitelist").then((response2) => {
+        setUsers(response2.data.whitelistUsers);
+        setUseWhitelist(response2.data.useWhitelist);
+      });
+      setLoading(false);
+      setSuccess(true);
+      setTimeout(() => {
+        setSuccess(false);
+      }, 3e3);
+    });
+  };
+  return /* @__PURE__ */ jsxRuntime.jsxs(admin.Page.Protect, { permissions: [{ action: "plugin::strapi-plugin-sso.read", subject: null }], children: [
+    /* @__PURE__ */ jsxRuntime.jsx(
+      admin.Layouts.Header,
+      {
+        title: "Single Sign On",
+        subtitle: formatMessage({
+          id: getTrad("page.title"),
+          defaultMessage: "Default role setting at first login"
+        })
+      }
+    ),
+    showSuccess && /* @__PURE__ */ jsxRuntime.jsx(SuccessAlertMessage, { onClose: () => setSuccess(false) }),
+    showError && /* @__PURE__ */ jsxRuntime.jsx(ErrorAlertMessage, { onClose: () => setError(false) }),
+    /* @__PURE__ */ jsxRuntime.jsx(designSystem.Box, { padding: 10, children: /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Tabs.Root, { defaultValue: "role", children: [
+      /* @__PURE__ */ jsxRuntime.jsxs(designSystem.Tabs.List, { "aria-label": "Manage your attribute", style: { maxWidth: 300 }, children: [
+        /* @__PURE__ */ jsxRuntime.jsx(designSystem.Tabs.Trigger, { value: "role", children: formatMessage({
+          id: getTrad("tab.roles"),
+          defaultMessage: "Roles"
+        }) }),
+        /* @__PURE__ */ jsxRuntime.jsx(designSystem.Tabs.Trigger, { value: "whitelist", children: formatMessage({
+          id: getTrad("tab.whitelist"),
+          defaultMessage: "Whitelist"
+        }) })
+      ] }),
+      /* @__PURE__ */ jsxRuntime.jsx(designSystem.Tabs.Content, { value: "role", style: { background: "initial" }, children: /* @__PURE__ */ jsxRuntime.jsx(
+        Role,
+        {
+          roles,
+          ssoRoles,
+          onSaveRole,
+          onChangeRoleCheck
+        }
+      ) }),
+      /* @__PURE__ */ jsxRuntime.jsx(designSystem.Tabs.Content, { value: "whitelist", children: /* @__PURE__ */ jsxRuntime.jsx(
+        Whitelist,
+        {
+          loading,
+          users,
+          useWhitelist,
+          onSave: onRegisterWhitelist,
+          onDelete: onDeleteWhitelist
+        }
+      ) })
+    ] }) })
+  ] });
+};
+const HomePage$1 = react.memo(HomePage);
+const App = () => {
+  return /* @__PURE__ */ jsxRuntime.jsx("div", { children: /* @__PURE__ */ jsxRuntime.jsxs(reactRouterDom.Routes, { children: [
+    /* @__PURE__ */ jsxRuntime.jsx(reactRouterDom.Route, { index: true, element: /* @__PURE__ */ jsxRuntime.jsx(HomePage$1, {}) }),
+    /* @__PURE__ */ jsxRuntime.jsx(reactRouterDom.Route, { path: "*", element: /* @__PURE__ */ jsxRuntime.jsx(admin.Page.Error, {}) })
+  ] }) });
+};
+exports.default = App;

--- a/dist/_chunks/index-BFqpFqpc.js
+++ b/dist/_chunks/index-BFqpFqpc.js
@@ -1,0 +1,86 @@
+"use strict";
+const react = require("react");
+const jsxRuntime = require("react/jsx-runtime");
+const icons = require("@strapi/icons");
+const __variableDynamicImportRuntimeHelper = (glob, path, segs) => {
+  const v = glob[path];
+  if (v) {
+    return typeof v === "function" ? v() : Promise.resolve(v);
+  }
+  return new Promise((_, reject) => {
+    (typeof queueMicrotask === "function" ? queueMicrotask : setTimeout)(
+      reject.bind(
+        null,
+        new Error(
+          "Unknown variable dynamic import: " + path + (path.split("/").length !== segs ? ". Note that variables only represent file names one level deep." : "")
+        )
+      )
+    );
+  });
+};
+const name$1 = "strapi-plugin-sso";
+const strapi = {
+  displayName: "Single Sign On"
+};
+const pluginPkg = {
+  name: name$1,
+  strapi
+};
+const pluginId = pluginPkg.name.replace(/^@strapi\/plugin-/i, "");
+const getTranslation = (id) => `${pluginId}.${id}`;
+const Initializer = ({ setPlugin }) => {
+  const ref = react.useRef();
+  ref.current = setPlugin;
+  react.useEffect(() => {
+    ref.current(pluginId);
+  }, []);
+  return null;
+};
+const PluginIcon = () => /* @__PURE__ */ jsxRuntime.jsx(icons.Lock, {});
+const name = pluginPkg.strapi.displayName;
+const index = {
+  register(app) {
+    app.addMenuLink({
+      to: `/plugins/${pluginId}`,
+      icon: PluginIcon,
+      intlLabel: {
+        id: `${pluginId}.plugin.name`,
+        defaultMessage: name
+      },
+      Component: async () => {
+        return await Promise.resolve().then(() => require("./index-6i2aMsbo.js"));
+      },
+      permissions: [{ action: "plugin::strapi-plugin-sso.read", subject: null }]
+    });
+    app.registerPlugin({
+      id: pluginId,
+      initializer: Initializer,
+      name
+    });
+  },
+  bootstrap(app) {
+  },
+  async registerTrads({ locales }) {
+    const importedTrads = await Promise.all(
+      locales.map((locale) => {
+        return __variableDynamicImportRuntimeHelper(/* @__PURE__ */ Object.assign({ "./translations/en.json": () => Promise.resolve().then(() => require("./en-BbQ9XzfO.js")), "./translations/fr.json": () => Promise.resolve().then(() => require("./fr-C8Qw4iPZ.js")), "./translations/ja.json": () => Promise.resolve().then(() => require("./ja-B2WcMFA2.js")) }), `./translations/${locale}.json`, 3).then(({ default: data }) => {
+          const newData = Object.fromEntries(
+            Object.entries(data).map(([key, value]) => [getTranslation(key), value])
+          );
+          return {
+            data: newData,
+            locale
+          };
+        }).catch(() => {
+          return {
+            data: {},
+            locale
+          };
+        });
+      })
+    );
+    return Promise.resolve(importedTrads);
+  }
+};
+exports.index = index;
+exports.pluginId = pluginId;

--- a/dist/_chunks/index-BGCMT5rK.mjs
+++ b/dist/_chunks/index-BGCMT5rK.mjs
@@ -1,0 +1,87 @@
+import { useRef, useEffect } from "react";
+import { jsx } from "react/jsx-runtime";
+import { Lock } from "@strapi/icons";
+const __variableDynamicImportRuntimeHelper = (glob, path, segs) => {
+  const v = glob[path];
+  if (v) {
+    return typeof v === "function" ? v() : Promise.resolve(v);
+  }
+  return new Promise((_, reject) => {
+    (typeof queueMicrotask === "function" ? queueMicrotask : setTimeout)(
+      reject.bind(
+        null,
+        new Error(
+          "Unknown variable dynamic import: " + path + (path.split("/").length !== segs ? ". Note that variables only represent file names one level deep." : "")
+        )
+      )
+    );
+  });
+};
+const name$1 = "strapi-plugin-sso";
+const strapi = {
+  displayName: "Single Sign On"
+};
+const pluginPkg = {
+  name: name$1,
+  strapi
+};
+const pluginId = pluginPkg.name.replace(/^@strapi\/plugin-/i, "");
+const getTranslation = (id) => `${pluginId}.${id}`;
+const Initializer = ({ setPlugin }) => {
+  const ref = useRef();
+  ref.current = setPlugin;
+  useEffect(() => {
+    ref.current(pluginId);
+  }, []);
+  return null;
+};
+const PluginIcon = () => /* @__PURE__ */ jsx(Lock, {});
+const name = pluginPkg.strapi.displayName;
+const index = {
+  register(app) {
+    app.addMenuLink({
+      to: `/plugins/${pluginId}`,
+      icon: PluginIcon,
+      intlLabel: {
+        id: `${pluginId}.plugin.name`,
+        defaultMessage: name
+      },
+      Component: async () => {
+        return await import("./index-C09Oa13a.mjs");
+      },
+      permissions: [{ action: "plugin::strapi-plugin-sso.read", subject: null }]
+    });
+    app.registerPlugin({
+      id: pluginId,
+      initializer: Initializer,
+      name
+    });
+  },
+  bootstrap(app) {
+  },
+  async registerTrads({ locales }) {
+    const importedTrads = await Promise.all(
+      locales.map((locale) => {
+        return __variableDynamicImportRuntimeHelper(/* @__PURE__ */ Object.assign({ "./translations/en.json": () => import("./en-AsM8uCFB.mjs"), "./translations/fr.json": () => import("./fr-hkSxFuzl.mjs"), "./translations/ja.json": () => import("./ja-COdupAQd.mjs") }), `./translations/${locale}.json`, 3).then(({ default: data }) => {
+          const newData = Object.fromEntries(
+            Object.entries(data).map(([key, value]) => [getTranslation(key), value])
+          );
+          return {
+            data: newData,
+            locale
+          };
+        }).catch(() => {
+          return {
+            data: {},
+            locale
+          };
+        });
+      })
+    );
+    return Promise.resolve(importedTrads);
+  }
+};
+export {
+  index as i,
+  pluginId as p
+};

--- a/dist/_chunks/index-C09Oa13a.mjs
+++ b/dist/_chunks/index-C09Oa13a.mjs
@@ -1,0 +1,370 @@
+import { jsxs, Fragment, jsx } from "react/jsx-runtime";
+import { useState, useCallback, memo, useEffect } from "react";
+import { Routes, Route } from "react-router-dom";
+import { useFetchClient, Page, Layouts } from "@strapi/strapi/admin";
+import { Table, Thead, Tr, Th, Checkbox, Tbody, Td, Button, Box, Typography, Flex, Grid, Field, Divider, Dialog, IconButton, Alert, Tabs } from "@strapi/design-system";
+import { useIntl } from "react-intl";
+import { p as pluginId } from "./index-BGCMT5rK.mjs";
+import styled from "styled-components";
+import { Check, WarningCircle, Plus, Trash } from "@strapi/icons";
+const getTrad = (id) => `${pluginId}.${id}`;
+const ButtonWrapper = styled.div`
+    margin: 10px 0 0 0;
+
+    & button {
+        margin: 0 0 0 auto;
+    }
+`;
+const Description = styled.p`
+    font-size: 16px;
+    margin: 20px 0;
+`;
+function Role({ ssoRoles, roles, onSaveRole, onChangeRoleCheck }) {
+  const { formatMessage } = useIntl();
+  return /* @__PURE__ */ jsxs(Fragment, { children: [
+    /* @__PURE__ */ jsxs(Table, { colCount: roles.length + 1, rowCount: ssoRoles.length, children: [
+      /* @__PURE__ */ jsx(Thead, { children: /* @__PURE__ */ jsxs(Tr, { children: [
+        /* @__PURE__ */ jsx(Th, { children: /* @__PURE__ */ jsx(Checkbox, { style: { display: "none" } }) }),
+        roles.map((role) => /* @__PURE__ */ jsx(Th, { children: role["name"] }, role["id"]))
+      ] }) }),
+      /* @__PURE__ */ jsx(Tbody, { children: ssoRoles.map((ssoRole) => /* @__PURE__ */ jsxs(Tr, { children: [
+        /* @__PURE__ */ jsx(Td, { children: ssoRole["name"] }),
+        roles.map((role) => /* @__PURE__ */ jsx(Th, { children: /* @__PURE__ */ jsx(
+          Checkbox,
+          {
+            checked: ssoRole["role"] && ssoRole["role"].includes(role["id"]),
+            onCheckedChange: (value) => onChangeRoleCheck(value, ssoRole["oauth_type"], role["id"]),
+            children: ""
+          }
+        ) }, role["id"]))
+      ] }, ssoRole["oauth_type"])) })
+    ] }),
+    /* @__PURE__ */ jsx(Description, { children: formatMessage({
+      id: getTrad("page.notes"),
+      defaultMessage: "This will not be reflected for already registered users."
+    }) }),
+    /* @__PURE__ */ jsx(ButtonWrapper, { children: /* @__PURE__ */ jsx(Button, { variant: "default", onClick: onSaveRole, children: formatMessage({
+      id: getTrad("page.save"),
+      defaultMessage: "Save"
+    }) }) })
+  ] });
+}
+const LocalizedDate = ({ date }) => {
+  const userLocale = navigator.language || "en-US";
+  return new Intl.DateTimeFormat(userLocale, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit"
+  }).format(new Date(date));
+};
+function Whitelist({ users, useWhitelist, loading, onSave, onDelete }) {
+  const [email, setEmail] = useState("");
+  const { formatMessage } = useIntl();
+  const onSaveEmail = useCallback(async () => {
+    const emailText = email.trim();
+    if (users.some((user) => user.email === emailText)) {
+      alert(
+        formatMessage({
+          id: getTrad("tab.whitelist.error.unique"),
+          defaultMessage: "Already registered email address."
+        })
+      );
+    } else {
+      await onSave(emailText);
+      setEmail("");
+    }
+  }, [email, users]);
+  const isValidEmail = useCallback(() => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  }, [email]);
+  return /* @__PURE__ */ jsx(Fragment, { children: /* @__PURE__ */ jsxs(Box, { padding: 4, children: [
+    /* @__PURE__ */ jsxs(Typography, { tag: "div", children: [
+      useWhitelist && /* @__PURE__ */ jsxs(Fragment, { children: [
+        /* @__PURE__ */ jsxs(Flex, { children: [
+          /* @__PURE__ */ jsx(Check, { color: "green" }),
+          " ",
+          formatMessage({
+            id: getTrad("tab.whitelist.enabled"),
+            defaultMessage: "Whitelist is currently enabled."
+          }),
+          /* @__PURE__ */ jsx("br", {})
+        ] }),
+        formatMessage({
+          id: getTrad("tab.whitelist.description"),
+          defaultMessage: "Only the following email addresses are allowed to authenticate with SSO."
+        })
+      ] }),
+      !useWhitelist && /* @__PURE__ */ jsxs(Flex, { children: [
+        /* @__PURE__ */ jsx(WarningCircle, { color: "#dd0000" }),
+        " ",
+        formatMessage({
+          id: getTrad("tab.whitelist.disabled"),
+          defaultMessage: "Whitelist is currently disabled."
+        })
+      ] })
+    ] }),
+    /* @__PURE__ */ jsx(Grid.Root, { tag: "fieldset", gap: 4, padding: "0px", gridCols: 2, borderWidth: 0, marginTop: 5, marginBottom: 5, children: /* @__PURE__ */ jsxs(Grid.Item, { xs: 1, children: [
+      /* @__PURE__ */ jsx(Field.Root, { children: /* @__PURE__ */ jsx(
+        Field.Input,
+        {
+          type: "email",
+          disabled: loading,
+          value: email,
+          hasError: email && !isValidEmail(),
+          onChange: (e) => setEmail(e.currentTarget.value)
+        }
+      ) }),
+      " ",
+      /* @__PURE__ */ jsx(
+        Button,
+        {
+          startIcon: /* @__PURE__ */ jsx(Plus, {}),
+          disabled: loading || email.trim() === "" || !isValidEmail(),
+          loading,
+          onClick: onSaveEmail,
+          children: formatMessage({
+            id: getTrad("page.save"),
+            defaultMessage: "Save"
+          })
+        }
+      )
+    ] }) }),
+    /* @__PURE__ */ jsx(Divider, {}),
+    /* @__PURE__ */ jsxs(Table, { colCount: 4, rowCount: users.length, children: [
+      /* @__PURE__ */ jsx(Thead, { children: /* @__PURE__ */ jsxs(Tr, { children: [
+        /* @__PURE__ */ jsx(Th, { children: formatMessage({
+          id: getTrad("tab.whitelist.table.no"),
+          defaultMessage: "No"
+        }) }),
+        /* @__PURE__ */ jsx(Th, { children: formatMessage({
+          id: getTrad("tab.whitelist.table.email"),
+          defaultMessage: "Email"
+        }) }),
+        /* @__PURE__ */ jsx(Th, { children: formatMessage({
+          id: getTrad("tab.whitelist.table.created"),
+          defaultMessage: "Created At"
+        }) }),
+        /* @__PURE__ */ jsx(Th, { children: " " })
+      ] }) }),
+      /* @__PURE__ */ jsx(Tbody, { children: users.map((user) => /* @__PURE__ */ jsxs(Tr, { children: [
+        /* @__PURE__ */ jsx(Td, { children: user.id }),
+        /* @__PURE__ */ jsx(Td, { children: user.email }),
+        /* @__PURE__ */ jsx(Td, { children: /* @__PURE__ */ jsx(LocalizedDate, { date: user.createdAt }) }),
+        /* @__PURE__ */ jsx(Td, { children: /* @__PURE__ */ jsxs(Dialog.Root, { children: [
+          /* @__PURE__ */ jsx(Dialog.Trigger, { children: /* @__PURE__ */ jsx(IconButton, { label: "Delete", withTooltip: false, children: /* @__PURE__ */ jsx(Trash, {}) }) }),
+          /* @__PURE__ */ jsxs(Dialog.Content, { children: [
+            /* @__PURE__ */ jsx(Dialog.Header, { children: formatMessage({
+              id: getTrad("tab.whitelist.delete.title"),
+              defaultMessage: "Confirmation"
+            }) }),
+            /* @__PURE__ */ jsx(Dialog.Body, { icon: /* @__PURE__ */ jsx(WarningCircle, { fill: "danger600" }), children: /* @__PURE__ */ jsxs(Typography, { variant: "delta", children: [
+              formatMessage({
+                id: getTrad("tab.whitelist.delete.description"),
+                defaultMessage: "Are you sure you want to delete this?"
+              }),
+              /* @__PURE__ */ jsx("br", {}),
+              user.email
+            ] }) }),
+            /* @__PURE__ */ jsxs(Dialog.Footer, { children: [
+              /* @__PURE__ */ jsx(Dialog.Cancel, { children: /* @__PURE__ */ jsx(Button, { fullWidth: true, variant: "tertiary", children: formatMessage({
+                id: getTrad("page.cancel"),
+                defaultMessage: "Cancel"
+              }) }) }),
+              /* @__PURE__ */ jsx(Dialog.Action, { children: /* @__PURE__ */ jsx(Button, { fullWidth: true, variant: "danger-light", onClick: () => onDelete(user.id), children: formatMessage({
+                id: getTrad("page.ok"),
+                defaultMessage: "OK"
+              }) }) })
+            ] })
+          ] })
+        ] }) })
+      ] }, user.id)) })
+    ] })
+  ] }) });
+}
+const AlertMessage = styled.div`
+    margin-left: -250px;
+    position: fixed;
+    left: 50%;
+    top: 2.875rem;
+    z-index: 10;
+    width: 31.25rem;
+`;
+function SuccessAlertMessage({ onClose: onClose2 }) {
+  const { formatMessage } = useIntl();
+  return /* @__PURE__ */ jsx(AlertMessage, { children: /* @__PURE__ */ jsx(
+    Alert,
+    {
+      title: "Success",
+      variant: "success",
+      closeLabel: "",
+      onClose: onClose2,
+      children: formatMessage({
+        id: getTrad("page.save.success"),
+        defaultMessage: "Updated settings"
+      })
+    }
+  ) });
+}
+function ErrorAlertMessage() {
+  const { formatMessage } = useIntl();
+  return /* @__PURE__ */ jsx(AlertMessage, { children: /* @__PURE__ */ jsx(
+    Alert,
+    {
+      title: "Error",
+      variant: "danger",
+      closeLabel: "",
+      onClose,
+      children: formatMessage({
+        id: getTrad("page.save.error"),
+        defaultMessage: "Update failed."
+      })
+    }
+  ) });
+}
+const HomePage = () => {
+  const { formatMessage } = useIntl();
+  const [loading, setLoading] = useState(false);
+  const [ssoRoles, setSSORoles] = useState([]);
+  const [roles, setRoles] = useState([]);
+  const [useWhitelist, setUseWhitelist] = useState(false);
+  const [users, setUsers] = useState([]);
+  const [showSuccess, setSuccess] = useState(false);
+  const [showError, setError] = useState(false);
+  const { get, put, post, del } = useFetchClient();
+  useEffect(() => {
+    get(`/strapi-plugin-sso/sso-roles`).then((response) => {
+      setSSORoles(response.data);
+    });
+    get(`/admin/roles`).then((response) => {
+      setRoles(response.data.data);
+    });
+    get("/strapi-plugin-sso/whitelist").then((response) => {
+      setUsers(response.data.whitelistUsers);
+      setUseWhitelist(response.data.useWhitelist);
+    });
+  }, [setSSORoles, setRoles]);
+  const onChangeRoleCheck = (value, ssoId, role) => {
+    for (const ssoRole of ssoRoles) {
+      if (ssoRole["oauth_type"] === ssoId) {
+        if (ssoRole["role"]) {
+          if (value) {
+            ssoRole["role"].push(role);
+          } else {
+            ssoRole["role"] = ssoRole["role"].filter((selectRole) => selectRole !== role);
+          }
+        } else {
+          ssoRole["role"] = [role];
+        }
+      }
+    }
+    setSSORoles(ssoRoles.slice());
+  };
+  const onSaveRole = async () => {
+    try {
+      await put("/strapi-plugin-sso/sso-roles", {
+        roles: ssoRoles.map((role) => ({
+          "oauth_type": role["oauth_type"],
+          role: role["role"]
+        }))
+      });
+      setSuccess(true);
+      setTimeout(() => {
+        setSuccess(false);
+      }, 3e3);
+    } catch (e) {
+      console.error(e);
+      setError(true);
+      setTimeout(() => {
+        setError(false);
+      }, 3e3);
+    }
+  };
+  const onRegisterWhitelist = async (email) => {
+    setLoading(true);
+    post("/strapi-plugin-sso/whitelist", {
+      email
+    }).then((response) => {
+      get("/strapi-plugin-sso/whitelist").then((response2) => {
+        setUsers(response2.data.whitelistUsers);
+        setUseWhitelist(response2.data.useWhitelist);
+      });
+      setLoading(false);
+      setSuccess(true);
+      setTimeout(() => {
+        setSuccess(false);
+      }, 3e3);
+    });
+  };
+  const onDeleteWhitelist = async (id) => {
+    setLoading(true);
+    del(`/strapi-plugin-sso/whitelist/${id}`).then((response) => {
+      get("/strapi-plugin-sso/whitelist").then((response2) => {
+        setUsers(response2.data.whitelistUsers);
+        setUseWhitelist(response2.data.useWhitelist);
+      });
+      setLoading(false);
+      setSuccess(true);
+      setTimeout(() => {
+        setSuccess(false);
+      }, 3e3);
+    });
+  };
+  return /* @__PURE__ */ jsxs(Page.Protect, { permissions: [{ action: "plugin::strapi-plugin-sso.read", subject: null }], children: [
+    /* @__PURE__ */ jsx(
+      Layouts.Header,
+      {
+        title: "Single Sign On",
+        subtitle: formatMessage({
+          id: getTrad("page.title"),
+          defaultMessage: "Default role setting at first login"
+        })
+      }
+    ),
+    showSuccess && /* @__PURE__ */ jsx(SuccessAlertMessage, { onClose: () => setSuccess(false) }),
+    showError && /* @__PURE__ */ jsx(ErrorAlertMessage, { onClose: () => setError(false) }),
+    /* @__PURE__ */ jsx(Box, { padding: 10, children: /* @__PURE__ */ jsxs(Tabs.Root, { defaultValue: "role", children: [
+      /* @__PURE__ */ jsxs(Tabs.List, { "aria-label": "Manage your attribute", style: { maxWidth: 300 }, children: [
+        /* @__PURE__ */ jsx(Tabs.Trigger, { value: "role", children: formatMessage({
+          id: getTrad("tab.roles"),
+          defaultMessage: "Roles"
+        }) }),
+        /* @__PURE__ */ jsx(Tabs.Trigger, { value: "whitelist", children: formatMessage({
+          id: getTrad("tab.whitelist"),
+          defaultMessage: "Whitelist"
+        }) })
+      ] }),
+      /* @__PURE__ */ jsx(Tabs.Content, { value: "role", style: { background: "initial" }, children: /* @__PURE__ */ jsx(
+        Role,
+        {
+          roles,
+          ssoRoles,
+          onSaveRole,
+          onChangeRoleCheck
+        }
+      ) }),
+      /* @__PURE__ */ jsx(Tabs.Content, { value: "whitelist", children: /* @__PURE__ */ jsx(
+        Whitelist,
+        {
+          loading,
+          users,
+          useWhitelist,
+          onSave: onRegisterWhitelist,
+          onDelete: onDeleteWhitelist
+        }
+      ) })
+    ] }) })
+  ] });
+};
+const HomePage$1 = memo(HomePage);
+const App = () => {
+  return /* @__PURE__ */ jsx("div", { children: /* @__PURE__ */ jsxs(Routes, { children: [
+    /* @__PURE__ */ jsx(Route, { index: true, element: /* @__PURE__ */ jsx(HomePage$1, {}) }),
+    /* @__PURE__ */ jsx(Route, { path: "*", element: /* @__PURE__ */ jsx(Page.Error, {}) })
+  ] }) });
+};
+export {
+  App as default
+};

--- a/dist/_chunks/ja-B2WcMFA2.js
+++ b/dist/_chunks/ja-B2WcMFA2.js
@@ -1,0 +1,23 @@
+"use strict";
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const ja = {
+  "page.title": "初回ログイン時のデフォルトロール設定",
+  "page.notes": "既に登録済みのユーザーには反映されません",
+  "page.save": "保存",
+  "page.save.success": "設定を更新しました",
+  "page.save.error": "設定の更新に失敗しました",
+  "page.cancel": "キャンセル",
+  "page.ok": "OK",
+  "tab.roles": "権限",
+  "tab.whitelist": "ホワイトリスト",
+  "tab.whitelist.error.unique": "既に登録されているメールアドレスです",
+  "tab.whitelist.enabled": "ホワイトリストは有効です",
+  "tab.whitelist.disabled": "ホワイトリストは無効です",
+  "tab.whitelist.description": "SSOで認証できるのは以下のメールアドレスのみです。",
+  "tab.whitelist.table.no": "No",
+  "tab.whitelist.table.email": "メールアドレス",
+  "tab.whitelist.table.created": "登録日",
+  "tab.whitelist.delete.title": "確認",
+  "tab.whitelist.delete.description": "本当に削除しますか？"
+};
+exports.default = ja;

--- a/dist/_chunks/ja-COdupAQd.mjs
+++ b/dist/_chunks/ja-COdupAQd.mjs
@@ -1,0 +1,23 @@
+const ja = {
+  "page.title": "初回ログイン時のデフォルトロール設定",
+  "page.notes": "既に登録済みのユーザーには反映されません",
+  "page.save": "保存",
+  "page.save.success": "設定を更新しました",
+  "page.save.error": "設定の更新に失敗しました",
+  "page.cancel": "キャンセル",
+  "page.ok": "OK",
+  "tab.roles": "権限",
+  "tab.whitelist": "ホワイトリスト",
+  "tab.whitelist.error.unique": "既に登録されているメールアドレスです",
+  "tab.whitelist.enabled": "ホワイトリストは有効です",
+  "tab.whitelist.disabled": "ホワイトリストは無効です",
+  "tab.whitelist.description": "SSOで認証できるのは以下のメールアドレスのみです。",
+  "tab.whitelist.table.no": "No",
+  "tab.whitelist.table.email": "メールアドレス",
+  "tab.whitelist.table.created": "登録日",
+  "tab.whitelist.delete.title": "確認",
+  "tab.whitelist.delete.description": "本当に削除しますか？"
+};
+export {
+  ja as default
+};

--- a/dist/admin/index.js
+++ b/dist/admin/index.js
@@ -1,0 +1,3 @@
+"use strict";
+const index = require("../_chunks/index-BFqpFqpc.js");
+module.exports = index.index;

--- a/dist/admin/index.mjs
+++ b/dist/admin/index.mjs
@@ -1,0 +1,4 @@
+import { i } from "../_chunks/index-BGCMT5rK.mjs";
+export {
+  i as default
+};

--- a/dist/server/index.js
+++ b/dist/server/index.js
@@ -1,0 +1,1001 @@
+"use strict";
+const axios = require("axios");
+const buffer = require("buffer");
+const node_crypto = require("node:crypto");
+const pkceChallenge = require("pkce-challenge");
+const strapiUtils = require("@strapi/utils");
+const generator = require("generate-password");
+const _interopDefault = (e) => e && e.__esModule ? e : { default: e };
+const axios__default = /* @__PURE__ */ _interopDefault(axios);
+const pkceChallenge__default = /* @__PURE__ */ _interopDefault(pkceChallenge);
+const strapiUtils__default = /* @__PURE__ */ _interopDefault(strapiUtils);
+const generator__default = /* @__PURE__ */ _interopDefault(generator);
+const register$1 = ({ strapi: strapi2 }) => {
+};
+const bootstrap = async ({ strapi: strapi2 }) => {
+  const actions = [
+    {
+      section: "plugins",
+      displayName: "Read",
+      uid: "read",
+      pluginName: "strapi-plugin-sso"
+    }
+  ];
+  await strapi2.admin.services.permission.actionProvider.registerMany(actions);
+};
+const destroy = ({ strapi: strapi2 }) => {
+};
+const config = {
+  default: {
+    REMEMBER_ME: false,
+    GOOGLE_OAUTH_REDIRECT_URI: "http://localhost:1337/strapi-plugin-sso/google/callback",
+    GOOGLE_GSUITE_HD: "",
+    GOOGLE_ALIAS: "",
+    COGNITO_OAUTH_REDIRECT_URI: "http://localhost:1337/strapi-plugin-sso/cognito/callback",
+    COGNITO_OAUTH_REGION: "ap-northeast-1",
+    AZUREAD_OAUTH_REDIRECT_URI: "http://localhost:1337/strapi-plugin-sso/azuread/callback",
+    AZUREAD_TENANT_ID: "",
+    AZUREAD_OAUTH_CLIENT_ID: "",
+    AZUREAD_OAUTH_CLIENT_SECRET: "",
+    AZUREAD_SCOPE: "user.read",
+    OIDC_REDIRECT_URI: "http://localhost:1337/strapi-plugin-sso/oidc/callback",
+    OIDC_CLIENT_ID: "",
+    OIDC_CLIENT_SECRET: "",
+    OIDC_SCOPES: "openid profile email",
+    OIDC_AUTHORIZATION_ENDPOINT: "",
+    OIDC_TOKEN_ENDPOINT: "",
+    OIDC_USER_INFO_ENDPOINT: "",
+    OIDC_USER_INFO_ENDPOINT_WITH_AUTH_HEADER: false,
+    OIDC_GRANT_TYPE: "authorization_code",
+    OIDC_FAMILY_NAME_FIELD: "family_name",
+    OIDC_GIVEN_NAME_FIELD: "given_name"
+  },
+  validator() {
+  }
+};
+const info$2 = {
+  singularName: "roles",
+  pluralName: "sso-roles",
+  collectionName: "sso-roles",
+  displayName: "sso-role",
+  description: ""
+};
+const options$1 = {
+  draftAndPublish: false
+};
+const pluginOptions$1 = {
+  "content-manager": {
+    visible: false
+  },
+  "content-type-builder": {
+    visible: false
+  }
+};
+const attributes$1 = {
+  oauth_type: {
+    type: "string",
+    configurable: false,
+    required: true
+  },
+  roles: {
+    type: "json",
+    configurable: false
+  }
+};
+const schema$1 = {
+  info: info$2,
+  options: options$1,
+  pluginOptions: pluginOptions$1,
+  attributes: attributes$1
+};
+const roles = {
+  schema: schema$1
+};
+const info$1 = {
+  singularName: "whitelists",
+  pluralName: "whitelists",
+  collectionName: "whitelists",
+  displayName: "whitelist",
+  description: ""
+};
+const options = {
+  draftAndPublish: false
+};
+const pluginOptions = {
+  "content-manager": {
+    visible: false
+  },
+  "content-type-builder": {
+    visible: false
+  }
+};
+const attributes = {
+  email: {
+    type: "string",
+    configurable: false,
+    required: true,
+    unique: true
+  }
+};
+const schema = {
+  info: info$1,
+  options,
+  pluginOptions,
+  attributes
+};
+const whitelists = {
+  schema
+};
+const contentTypes = {
+  roles,
+  whitelists
+};
+const configValidation$3 = () => {
+  const config2 = strapi.config.get("plugin::strapi-plugin-sso");
+  if (config2["GOOGLE_OAUTH_CLIENT_ID"] && config2["GOOGLE_OAUTH_CLIENT_SECRET"]) {
+    return config2;
+  }
+  throw new Error("GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET are required");
+};
+const OAUTH_ENDPOINT$2 = "https://accounts.google.com/o/oauth2/auth";
+const OAUTH_TOKEN_ENDPOINT$2 = "https://accounts.google.com/o/oauth2/token";
+const OAUTH_USER_INFO_ENDPOINT$2 = "https://www.googleapis.com/oauth2/v1/userinfo";
+const OAUTH_GRANT_TYPE$2 = "authorization_code";
+const OAUTH_RESPONSE_TYPE$2 = "code";
+const OAUTH_SCOPE$1 = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile";
+async function googleSignIn(ctx) {
+  const config2 = configValidation$3();
+  const { code_verifier: codeVerifier, code_challenge: codeChallenge } = pkceChallenge__default.default();
+  ctx.session.codeVerifier = codeVerifier;
+  const state = node_crypto.getRandomValues(buffer.Buffer.alloc(32)).toString("base64url");
+  ctx.session.oidcState = state;
+  const params = new URLSearchParams();
+  params.append("client_id", config2["GOOGLE_OAUTH_CLIENT_ID"]);
+  params.append("redirect_uri", config2["GOOGLE_OAUTH_REDIRECT_URI"]);
+  params.append("scope", OAUTH_SCOPE$1);
+  params.append("response_type", OAUTH_RESPONSE_TYPE$2);
+  params.append("code_challenge", codeChallenge);
+  params.append("code_challenge_method", "S256");
+  params.append("state", state);
+  const url = `${OAUTH_ENDPOINT$2}?${params.toString()}`;
+  ctx.set("Location", url);
+  return ctx.send({}, 302);
+}
+async function googleSignInCallback(ctx) {
+  const config2 = configValidation$3();
+  const httpClient = axios__default.default.create();
+  const userService = strapi.service("admin::user");
+  const oauthService = strapi.plugin("strapi-plugin-sso").service("oauth");
+  const roleService = strapi.plugin("strapi-plugin-sso").service("role");
+  const whitelistService = strapi.plugin("strapi-plugin-sso").service("whitelist");
+  if (!ctx.query.code) {
+    return ctx.send(oauthService.renderSignUpError(`code Not Found`));
+  }
+  if (!ctx.query.state || ctx.query.state !== ctx.session.oidcState) {
+    return ctx.send(oauthService.renderSignUpError(`Invalid state`));
+  }
+  const params = new URLSearchParams();
+  params.append("code", ctx.query.code);
+  params.append("client_id", config2["GOOGLE_OAUTH_CLIENT_ID"]);
+  params.append("client_secret", config2["GOOGLE_OAUTH_CLIENT_SECRET"]);
+  params.append("redirect_uri", config2["GOOGLE_OAUTH_REDIRECT_URI"]);
+  params.append("grant_type", OAUTH_GRANT_TYPE$2);
+  params.append("code_verifier", ctx.session.codeVerifier);
+  try {
+    const response = await httpClient.post(OAUTH_TOKEN_ENDPOINT$2, params, {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      }
+    });
+    const userInfoEndpoint = `${OAUTH_USER_INFO_ENDPOINT$2}?access_token=${response.data.access_token}`;
+    const userResponse = await httpClient.get(userInfoEndpoint);
+    if (config2["GOOGLE_GSUITE_HD"]) {
+      if (userResponse.data.hd !== config2["GOOGLE_GSUITE_HD"]) {
+        throw new Error("Unauthorized email address");
+      }
+    }
+    const email = config2["GOOGLE_ALIAS"] ? oauthService.addGmailAlias(userResponse.data.email, config2["GOOGLE_ALIAS"]) : userResponse.data.email;
+    await whitelistService.checkWhitelistForEmail(email);
+    const dbUser = await userService.findOneByEmail(email);
+    let activateUser;
+    let jwtToken;
+    if (dbUser) {
+      activateUser = dbUser;
+      jwtToken = await oauthService.generateToken(dbUser, ctx);
+    } else {
+      const googleRoles = await roleService.googleRoles();
+      const roles2 = googleRoles && googleRoles["roles"] ? googleRoles["roles"].map((role2) => ({
+        id: role2
+      })) : [];
+      const defaultLocale = oauthService.localeFindByHeader(ctx.request.headers);
+      activateUser = await oauthService.createUser(
+        email,
+        userResponse.data.family_name,
+        userResponse.data.given_name,
+        defaultLocale,
+        roles2
+      );
+      jwtToken = await oauthService.generateToken(activateUser, ctx);
+      await oauthService.triggerWebHook(activateUser);
+    }
+    oauthService.triggerSignInSuccess(activateUser);
+    const nonce = node_crypto.randomUUID();
+    const html = oauthService.renderSignUpSuccess(jwtToken, activateUser, nonce);
+    ctx.set("Content-Security-Policy", `script-src 'nonce-${nonce}'`);
+    ctx.send(html);
+  } catch (e) {
+    console.error(e);
+    ctx.send(oauthService.renderSignUpError(e.message));
+  }
+}
+const google = {
+  googleSignIn,
+  googleSignInCallback
+};
+const configValidation$2 = () => {
+  const config2 = strapi.config.get("plugin::strapi-plugin-sso");
+  if (config2["COGNITO_OAUTH_CLIENT_ID"] && config2["COGNITO_OAUTH_CLIENT_SECRET"] && config2["COGNITO_OAUTH_DOMAIN"]) {
+    return config2;
+  }
+  throw new Error("COGNITO_OAUTH_CLIENT_ID, COGNITO_OAUTH_CLIENT_SECRET AND COGNITO_OAUTH_DOMAIN are required");
+};
+const OAUTH_ENDPOINT$1 = (domain, region) => {
+  return `https://${domain}.auth.${region}.amazoncognito.com/oauth2/authorize`;
+};
+const OAUTH_TOKEN_ENDPOINT$1 = (domain, region) => {
+  return `https://${domain}.auth.${region}.amazoncognito.com/oauth2/token`;
+};
+const OAUTH_USER_INFO_ENDPOINT$1 = (domain, region) => {
+  return `https://${domain}.auth.${region}.amazoncognito.com/oauth2/userInfo`;
+};
+const OAUTH_GRANT_TYPE$1 = "authorization_code";
+const OAUTH_SCOPE = "openid email profile";
+const OAUTH_RESPONSE_TYPE$1 = "code";
+async function cognitoSignIn(ctx) {
+  const config2 = configValidation$2();
+  const endpoint = OAUTH_ENDPOINT$1(config2["COGNITO_OAUTH_DOMAIN"], config2["COGNITO_OAUTH_REGION"]);
+  const { code_verifier: codeVerifier, code_challenge: codeChallenge } = pkceChallenge__default.default();
+  ctx.session.codeVerifier = codeVerifier;
+  const state = node_crypto.getRandomValues(buffer.Buffer.alloc(32)).toString("base64url");
+  ctx.session.oidcState = state;
+  const params = new URLSearchParams();
+  params.append("client_id", config2["COGNITO_OAUTH_CLIENT_ID"]);
+  params.append("redirect_uri", config2["COGNITO_OAUTH_REDIRECT_URI"]);
+  params.append("scope", OAUTH_SCOPE);
+  params.append("response_type", OAUTH_RESPONSE_TYPE$1);
+  params.append("code_challenge", codeChallenge);
+  params.append("code_challenge_method", "S256");
+  params.append("state", state);
+  const url = `${endpoint}?${params.toString()}`;
+  ctx.set("Location", url);
+  return ctx.send({}, 302);
+}
+async function cognitoSignInCallback(ctx) {
+  const config2 = configValidation$2();
+  const userService = strapi.service("admin::user");
+  const oauthService = strapi.plugin("strapi-plugin-sso").service("oauth");
+  const roleService = strapi.plugin("strapi-plugin-sso").service("role");
+  const whitelistService = strapi.plugin("strapi-plugin-sso").service("whitelist");
+  if (!ctx.query.code) {
+    return ctx.send(oauthService.renderSignUpError(`code Not Found`));
+  }
+  if (!ctx.query.state || ctx.query.state !== ctx.session.oidcState) {
+    return ctx.send(oauthService.renderSignUpError(`Invalid state`));
+  }
+  const params = new URLSearchParams();
+  params.append("code", ctx.query.code);
+  params.append("client_id", config2["COGNITO_OAUTH_CLIENT_ID"]);
+  params.append("client_secret", config2["COGNITO_OAUTH_CLIENT_SECRET"]);
+  params.append("redirect_uri", config2["COGNITO_OAUTH_REDIRECT_URI"]);
+  params.append("grant_type", OAUTH_GRANT_TYPE$1);
+  params.append("code_verifier", ctx.session.codeVerifier);
+  try {
+    const tokenEndpoint = OAUTH_TOKEN_ENDPOINT$1(config2["COGNITO_OAUTH_DOMAIN"], config2["COGNITO_OAUTH_REGION"]);
+    const userInfoEndpoint = OAUTH_USER_INFO_ENDPOINT$1(config2["COGNITO_OAUTH_DOMAIN"], config2["COGNITO_OAUTH_REGION"]);
+    const response = await axios__default.default.post(tokenEndpoint, params, {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      }
+    });
+    const userResponse = await axios__default.default.get(userInfoEndpoint, {
+      headers: {
+        Authorization: `Bearer ${response.data.access_token}`
+      }
+    });
+    if (userResponse.data.email_verified !== "true") {
+      throw new Error("Your email address has not been verified.");
+    }
+    const userGroup = config2["COGNITO_USER_GROUP"];
+    if (userGroup) {
+      const claims = JSON.parse(buffer.Buffer.from(response.data.access_token.split(".")[1], "base64").toString());
+      if ((claims["cognito:groups"] || []).includes(userGroup) === false) {
+        throw new Error("You do not belong to the specified user group.");
+      }
+    }
+    await whitelistService.checkWhitelistForEmail(userResponse.data.email);
+    const dbUser = await userService.findOneByEmail(userResponse.data.email);
+    let activateUser;
+    let jwtToken;
+    if (dbUser) {
+      activateUser = dbUser;
+      jwtToken = await oauthService.generateToken(dbUser, ctx);
+    } else {
+      const cognitoRoles = await roleService.cognitoRoles();
+      const roles2 = cognitoRoles && cognitoRoles["roles"] ? cognitoRoles["roles"].map((role2) => ({
+        id: role2
+      })) : [];
+      const defaultLocale = oauthService.localeFindByHeader(ctx.request.headers);
+      activateUser = await oauthService.createUser(
+        userResponse.data.email,
+        "",
+        userResponse.data.username,
+        defaultLocale,
+        roles2
+      );
+      jwtToken = await oauthService.generateToken(activateUser, ctx);
+      await oauthService.triggerWebHook(activateUser);
+    }
+    oauthService.triggerSignInSuccess(activateUser);
+    const nonce = node_crypto.randomUUID();
+    const html = oauthService.renderSignUpSuccess(jwtToken, activateUser, nonce);
+    ctx.set("Content-Security-Policy", `script-src 'nonce-${nonce}'`);
+    ctx.send(html);
+  } catch (e) {
+    console.error(e);
+    ctx.send(oauthService.renderSignUpError(e.message));
+  }
+}
+const cognito = {
+  cognitoSignIn,
+  cognitoSignInCallback
+};
+const configValidation$1 = () => {
+  const config2 = strapi.config.get("plugin::strapi-plugin-sso");
+  if (config2["AZUREAD_OAUTH_CLIENT_ID"] && config2["AZUREAD_OAUTH_CLIENT_SECRET"] && config2["AZUREAD_TENANT_ID"]) {
+    return config2;
+  }
+  throw new Error(
+    "AZUREAD_OAUTH_CLIENT_ID, AZUREAD_OAUTH_CLIENT_SECRET, and AZUREAD_TENANT_ID are required"
+  );
+};
+const OAUTH_ENDPOINT = (tenantId) => `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/authorize`;
+const OAUTH_TOKEN_ENDPOINT = (tenantId) => `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
+const OAUTH_USER_INFO_ENDPOINT = "https://graph.microsoft.com/oidc/userinfo";
+const OAUTH_GRANT_TYPE = "authorization_code";
+const OAUTH_RESPONSE_TYPE = "code";
+async function azureAdSignIn(ctx) {
+  const config2 = configValidation$1();
+  const endpoint = OAUTH_ENDPOINT(config2["AZUREAD_TENANT_ID"]);
+  const { code_verifier: codeVerifier, code_challenge: codeChallenge } = pkceChallenge__default.default();
+  ctx.session.codeVerifier = codeVerifier;
+  const state = node_crypto.getRandomValues(buffer.Buffer.alloc(32)).toString("base64url");
+  ctx.session.oidcState = state;
+  const params = new URLSearchParams();
+  params.append("client_id", config2["AZUREAD_OAUTH_CLIENT_ID"]);
+  params.append("redirect_uri", config2["AZUREAD_OAUTH_REDIRECT_URI"]);
+  params.append("scope", config2["AZUREAD_SCOPE"]);
+  params.append("response_type", OAUTH_RESPONSE_TYPE);
+  params.append("code_challenge", codeChallenge);
+  params.append("code_challenge_method", "S256");
+  params.append("state", state);
+  const url = `${endpoint}?${params.toString()}`;
+  ctx.set("Location", url);
+  return ctx.send({}, 302);
+}
+async function azureAdSignInCallback(ctx) {
+  const config2 = configValidation$1();
+  const userService = strapi.service("admin::user");
+  const oauthService = strapi.plugin("strapi-plugin-sso").service("oauth");
+  const roleService = strapi.plugin("strapi-plugin-sso").service("role");
+  const whitelistService = strapi.plugin("strapi-plugin-sso").service("whitelist");
+  if (!ctx.query.code) {
+    return ctx.send(oauthService.renderSignUpError(`code Not Found`));
+  }
+  if (!ctx.query.state || ctx.query.state !== ctx.session.oidcState) {
+    return ctx.send(oauthService.renderSignUpError(`Invalid state`));
+  }
+  const params = new URLSearchParams();
+  params.append("code", ctx.query.code);
+  params.append("client_id", config2["AZUREAD_OAUTH_CLIENT_ID"]);
+  params.append("client_secret", config2["AZUREAD_OAUTH_CLIENT_SECRET"]);
+  params.append("redirect_uri", config2["AZUREAD_OAUTH_REDIRECT_URI"]);
+  params.append("grant_type", OAUTH_GRANT_TYPE);
+  params.append("code_verifier", ctx.session.codeVerifier);
+  try {
+    const tokenEndpoint = OAUTH_TOKEN_ENDPOINT(config2["AZUREAD_TENANT_ID"]);
+    const response = await axios__default.default.post(tokenEndpoint, params, {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      }
+    });
+    const userResponse = await axios__default.default.get(OAUTH_USER_INFO_ENDPOINT, {
+      headers: {
+        Authorization: `Bearer ${response.data.access_token}`
+      }
+    });
+    if (!userResponse.data.email) {
+      throw new Error("Email address is not set. Please set email property to the Azure AD user.");
+    }
+    await whitelistService.checkWhitelistForEmail(userResponse.data.email);
+    const dbUser = await userService.findOneByEmail(userResponse.data.email);
+    let activateUser;
+    let jwtToken;
+    if (dbUser) {
+      activateUser = dbUser;
+      jwtToken = await oauthService.generateToken(dbUser, ctx);
+    } else {
+      const azureAdRoles = await roleService.azureAdRoles();
+      const roles2 = azureAdRoles && azureAdRoles["roles"] ? azureAdRoles["roles"].map((role2) => ({
+        id: role2
+      })) : [];
+      const defaultLocale = oauthService.localeFindByHeader(
+        ctx.request.headers
+      );
+      activateUser = await oauthService.createUser(
+        userResponse.data.email,
+        userResponse.data.family_name,
+        userResponse.data.given_name,
+        defaultLocale,
+        roles2
+      );
+      jwtToken = await oauthService.generateToken(activateUser, ctx);
+      await oauthService.triggerWebHook(activateUser);
+    }
+    oauthService.triggerSignInSuccess(activateUser);
+    const nonce = node_crypto.randomUUID();
+    const html = oauthService.renderSignUpSuccess(
+      jwtToken,
+      activateUser,
+      nonce
+    );
+    ctx.set("Content-Security-Policy", `script-src 'nonce-${nonce}'`);
+    ctx.send(html);
+  } catch (e) {
+    console.error(e);
+    ctx.send(oauthService.renderSignUpError(e.message));
+  }
+}
+const azuread = {
+  azureAdSignIn,
+  azureAdSignInCallback
+};
+const configValidation = () => {
+  const config2 = strapi.config.get("plugin::strapi-plugin-sso");
+  if (config2["OIDC_CLIENT_ID"] && config2["OIDC_CLIENT_SECRET"] && config2["OIDC_REDIRECT_URI"] && config2["OIDC_SCOPES"] && config2["OIDC_TOKEN_ENDPOINT"] && config2["OIDC_USER_INFO_ENDPOINT"] && config2["OIDC_GRANT_TYPE"] && config2["OIDC_FAMILY_NAME_FIELD"] && config2["OIDC_GIVEN_NAME_FIELD"] && config2["OIDC_AUTHORIZATION_ENDPOINT"]) {
+    return config2;
+  }
+  throw new Error("OIDC_AUTHORIZATION_ENDPOINT,OIDC_TOKEN_ENDPOINT, OIDC_USER_INFO_ENDPOINT,OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_REDIRECT_URI, and OIDC_SCOPES are required");
+};
+const oidcSignIn = async (ctx) => {
+  let { state } = ctx.query;
+  const { OIDC_CLIENT_ID, OIDC_REDIRECT_URI, OIDC_SCOPES, OIDC_AUTHORIZATION_ENDPOINT } = configValidation();
+  const { code_verifier: codeVerifier, code_challenge: codeChallenge } = pkceChallenge__default.default();
+  ctx.session.codeVerifier = codeVerifier;
+  if (!state) {
+    state = node_crypto.getRandomValues(buffer.Buffer.alloc(32)).toString("base64url");
+  }
+  ctx.session.oidcState = state;
+  const params = new URLSearchParams();
+  params.append("response_type", "code");
+  params.append("client_id", OIDC_CLIENT_ID);
+  params.append("redirect_uri", OIDC_REDIRECT_URI);
+  params.append("scope", OIDC_SCOPES);
+  params.append("code_challenge", codeChallenge);
+  params.append("code_challenge_method", "S256");
+  params.append("state", state);
+  const authorizationUrl = `${OIDC_AUTHORIZATION_ENDPOINT}?${params.toString()}`;
+  ctx.set("Location", authorizationUrl);
+  return ctx.send({}, 302);
+};
+const oidcSignInCallback = async (ctx) => {
+  const config2 = configValidation();
+  const httpClient = axios__default.default.create();
+  const userService = strapi.service("admin::user");
+  const oauthService = strapi.plugin("strapi-plugin-sso").service("oauth");
+  const roleService = strapi.plugin("strapi-plugin-sso").service("role");
+  const whitelistService = strapi.plugin("strapi-plugin-sso").service("whitelist");
+  if (!ctx.query.code) {
+    return ctx.send(oauthService.renderSignUpError(`code Not Found`));
+  }
+  if (!ctx.query.state || ctx.query.state !== ctx.session.oidcState) {
+    return ctx.send(oauthService.renderSignUpError(`Invalid state`));
+  }
+  const params = new URLSearchParams();
+  params.append("code", ctx.query.code);
+  params.append("client_id", config2["OIDC_CLIENT_ID"]);
+  params.append("client_secret", config2["OIDC_CLIENT_SECRET"]);
+  params.append("redirect_uri", config2["OIDC_REDIRECT_URI"]);
+  params.append("grant_type", config2["OIDC_GRANT_TYPE"]);
+  params.append("code_verifier", ctx.session.codeVerifier);
+  try {
+    const response = await httpClient.post(config2["OIDC_TOKEN_ENDPOINT"], params, {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      }
+    });
+    let userInfoEndpointHeaders = {};
+    let userInfoEndpointParameters = `?access_token=${response.data.access_token}`;
+    if (config2["OIDC_USER_INFO_ENDPOINT_WITH_AUTH_HEADER"]) {
+      userInfoEndpointHeaders = {
+        headers: { Authorization: `Bearer ${response.data.access_token}` }
+      };
+      userInfoEndpointParameters = "";
+    }
+    const userInfoEndpoint = `${config2["OIDC_USER_INFO_ENDPOINT"]}${userInfoEndpointParameters}`;
+    const userResponse = await httpClient.get(
+      userInfoEndpoint,
+      userInfoEndpointHeaders
+    );
+    const email = userResponse.data.email;
+    await whitelistService.checkWhitelistForEmail(email);
+    const dbUser = await userService.findOneByEmail(email);
+    let activateUser;
+    let jwtToken;
+    if (dbUser) {
+      activateUser = dbUser;
+      jwtToken = await oauthService.generateToken(dbUser, ctx);
+    } else {
+      const oidcRoles = await roleService.oidcRoles();
+      const roles2 = oidcRoles && oidcRoles["roles"] ? oidcRoles["roles"].map((role2) => ({
+        id: role2
+      })) : [];
+      const defaultLocale = oauthService.localeFindByHeader(ctx.request.headers);
+      activateUser = await oauthService.createUser(
+        email,
+        userResponse.data[config2["OIDC_FAMILY_NAME_FIELD"]],
+        userResponse.data[config2["OIDC_GIVEN_NAME_FIELD"]],
+        defaultLocale,
+        roles2
+      );
+      jwtToken = await oauthService.generateToken(activateUser, ctx);
+      await oauthService.triggerWebHook(activateUser);
+    }
+    oauthService.triggerSignInSuccess(activateUser);
+    const nonce = node_crypto.randomUUID();
+    const html = oauthService.renderSignUpSuccess(jwtToken, activateUser, nonce);
+    ctx.set("Content-Security-Policy", `script-src 'nonce-${nonce}'`);
+    ctx.send(html);
+  } catch (e) {
+    console.error(e);
+    ctx.send(oauthService.renderSignUpError(e.message));
+  }
+};
+const oidc = {
+  oidcSignIn,
+  oidcSignInCallback
+};
+async function find(ctx) {
+  const roleService = strapi.plugin("strapi-plugin-sso").service("role");
+  const roles2 = await roleService.find();
+  const ssoConstants = roleService.ssoRoles();
+  for (const sso of ssoConstants) {
+    for (const role2 of roles2) {
+      if (role2["oauth_type"] === sso["oauth_type"]) {
+        sso["role"] = role2["roles"];
+      }
+    }
+  }
+  ctx.send(ssoConstants);
+}
+async function update(ctx) {
+  try {
+    const { roles: roles2 } = ctx.request.body;
+    const roleService = strapi.plugin("strapi-plugin-sso").service("role");
+    await roleService.update(roles2);
+    ctx.send({}, 204);
+  } catch (e) {
+    console.log(e);
+    ctx.send({}, 400);
+  }
+}
+const role$1 = {
+  find,
+  update
+};
+async function info(ctx) {
+  const config2 = strapi.config.get("plugin::strapi-plugin-sso");
+  const useWhitelist = config2["USE_WHITELIST"] === true;
+  let whitelistUsers = [];
+  const whitelistService = strapi.plugin("strapi-plugin-sso").service("whitelist");
+  whitelistUsers = await whitelistService.getUsers();
+  ctx.body = {
+    useWhitelist,
+    whitelistUsers
+  };
+}
+async function register(ctx) {
+  const { email } = ctx.request.body;
+  if (!email) {
+    ctx.body = {
+      message: "Please enter a valid email address"
+    };
+  }
+  const whitelistService = strapi.plugin("strapi-plugin-sso").service("whitelist");
+  await whitelistService.registerUser(email);
+  ctx.body = {};
+}
+async function removeEmail(ctx) {
+  const { id } = ctx.params;
+  const whitelistService = strapi.plugin("strapi-plugin-sso").service("whitelist");
+  await whitelistService.removeUser(id);
+  ctx.body = {};
+}
+const whitelist$1 = {
+  info,
+  register,
+  removeEmail
+};
+const controllers = {
+  google,
+  cognito,
+  azuread,
+  oidc,
+  role: role$1,
+  whitelist: whitelist$1
+};
+const routes = [
+  {
+    method: "GET",
+    path: "/google",
+    handler: "google.googleSignIn",
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: "GET",
+    path: "/google/callback",
+    handler: "google.googleSignInCallback",
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: "GET",
+    path: "/cognito",
+    handler: "cognito.cognitoSignIn",
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: "GET",
+    path: "/cognito/callback",
+    handler: "cognito.cognitoSignInCallback",
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: "GET",
+    path: "/azuread",
+    handler: "azuread.azureAdSignIn",
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: "GET",
+    path: "/azuread/callback",
+    handler: "azuread.azureAdSignInCallback",
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: "GET",
+    path: "/sso-roles",
+    handler: "role.find"
+  },
+  {
+    method: "PUT",
+    path: "/sso-roles",
+    handler: "role.update"
+  },
+  {
+    method: "GET",
+    path: "/oidc",
+    handler: "oidc.oidcSignIn",
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: "GET",
+    path: "/oidc/callback",
+    handler: "oidc.oidcSignInCallback",
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: "GET",
+    path: "/whitelist",
+    handler: "whitelist.info"
+  },
+  {
+    method: "POST",
+    path: "/whitelist",
+    handler: "whitelist.register"
+  },
+  {
+    method: "DELETE",
+    path: "/whitelist/:id",
+    handler: "whitelist.removeEmail"
+  }
+];
+const policies = {};
+const oauth = ({ strapi: strapi2 }) => ({
+  async createUser(email, lastname, firstname, locale, roles2 = []) {
+    const userService = strapi2.service("admin::user");
+    if (/[A-Z]/.test(email)) {
+      const dbUser = await userService.findOneByEmail(email.toLocaleLowerCase());
+      if (dbUser) {
+        return dbUser;
+      }
+    }
+    const createdUser = await userService.create({
+      firstname: firstname ? firstname : "unset",
+      lastname: lastname ? lastname : "",
+      email: email.toLocaleLowerCase(),
+      roles: roles2,
+      preferedLanguage: locale
+    });
+    return await userService.register({
+      registrationToken: createdUser.registrationToken,
+      userInfo: {
+        firstname: firstname ? firstname : "unset",
+        lastname: lastname ? lastname : "user",
+        password: generator__default.default.generate({
+          length: 43,
+          // 256 bits (https://en.wikipedia.org/wiki/Password_strength#Random_passwords)
+          numbers: true,
+          lowercase: true,
+          uppercase: true,
+          exclude: '()+_-=}{[]|:;"/?.><,`~',
+          strict: true
+        })
+      }
+    });
+  },
+  addGmailAlias(baseEmail, baseAlias) {
+    if (!baseAlias) {
+      return baseEmail;
+    }
+    const alias = baseAlias.replace("/+/g", "");
+    const beforePosition = baseEmail.indexOf("@");
+    const origin = baseEmail.substring(0, beforePosition);
+    const domain = baseEmail.substring(beforePosition);
+    return `${origin}+${alias}${domain}`;
+  },
+  localeFindByHeader(headers) {
+    if (headers["accept-language"] && headers["accept-language"].includes("ja")) {
+      return "ja";
+    } else {
+      return "en";
+    }
+  },
+  async triggerWebHook(user) {
+    let ENTRY_CREATE;
+    const webhookStore = strapi2.serviceMap.get("webhookStore");
+    const eventHub = strapi2.serviceMap.get("eventHub");
+    if (webhookStore) {
+      ENTRY_CREATE = webhookStore.allowedEvents.get("ENTRY_CREATE");
+    }
+    const modelDef = strapi2.getModel("admin::user");
+    const sanitizedEntity = await strapiUtils__default.default.sanitize.sanitizers.defaultSanitizeOutput({
+      schema: modelDef,
+      getModel: (uid2) => strapi2.getModel(uid2)
+    }, user);
+    eventHub.emit(ENTRY_CREATE, {
+      model: modelDef.modelName,
+      entry: sanitizedEntity
+    });
+  },
+  triggerSignInSuccess(user) {
+    delete user["password"];
+    const eventHub = strapi2.serviceMap.get("eventHub");
+    eventHub.emit("admin.auth.success", {
+      user,
+      provider: "strapi-plugin-sso"
+    });
+  },
+  // Sign In Success
+  renderSignUpSuccess(jwtToken, user, nonce) {
+    const config2 = strapi2.config.get("plugin::strapi-plugin-sso");
+    const REMEMBER_ME = config2["REMEMBER_ME"];
+    const isRememberMe = !!REMEMBER_ME;
+    return `
+<!doctype html>
+<html>
+<head>
+<noscript>
+<h3>JavaScript must be enabled for authentication</h3>
+</noscript>
+<script nonce="${nonce}">
+ window.addEventListener('load', function() {
+  if(${isRememberMe}){
+    localStorage.setItem('jwtToken', '"${jwtToken}"');
+  }else{
+    document.cookie = 'jwtToken=${encodeURIComponent(jwtToken)}; Path=/';
+  }
+  localStorage.setItem('isLoggedIn', 'true');
+  location.href = '${strapi2.config.admin.url}'
+ })
+<\/script>
+</head>
+<body>
+</body>
+</html>`;
+  },
+  // Sign In Error
+  renderSignUpError(message) {
+    return `
+<!doctype html>
+<html>
+<head></head>
+<body>
+<h3>Authentication failed</h3>
+<p>${message}</p>
+</body>
+</html>`;
+  },
+  async generateToken(user, ctx) {
+    const sessionManager = strapi2.sessionManager;
+    if (!sessionManager) {
+      throw new Error("sessionManager is not supported. Please upgrade to Strapi v5.24.1 or later.");
+    }
+    const userId = String(user.id);
+    const deviceId = node_crypto.randomUUID();
+    const config2 = strapi2.config.get("plugin::strapi-plugin-sso");
+    const REMEMBER_ME = config2["REMEMBER_ME"];
+    const rememberMe = !!REMEMBER_ME;
+    const { token: refreshToken } = await sessionManager(
+      "admin"
+    ).generateRefreshToken(userId, deviceId, {
+      type: rememberMe ? "refresh" : "session"
+    });
+    const cookieOptions = {};
+    ctx.cookies.set("strapi_admin_refresh", refreshToken, cookieOptions);
+    const accessResult = await sessionManager("admin").generateAccessToken(refreshToken);
+    if ("error" in accessResult) {
+      throw new Error(accessResult.error);
+    }
+    const { token: accessToken } = accessResult;
+    return accessToken;
+  }
+});
+const role = ({ strapi: strapi2 }) => ({
+  SSO_TYPE_GOOGLE: "1",
+  SSO_TYPE_COGNITO: "2",
+  SSO_TYPE_AZUREAD: "3",
+  SSO_TYPE_OIDC: "4",
+  ssoRoles() {
+    return [
+      {
+        "oauth_type": this.SSO_TYPE_GOOGLE,
+        name: "Google"
+      },
+      {
+        "oauth_type": this.SSO_TYPE_COGNITO,
+        name: "Cognito"
+      },
+      {
+        "oauth_type": this.SSO_TYPE_AZUREAD,
+        name: "AzureAD"
+      },
+      {
+        "oauth_type": this.SSO_TYPE_OIDC,
+        name: "OIDC"
+      }
+    ];
+  },
+  async googleRoles() {
+    return await strapi2.query("plugin::strapi-plugin-sso.roles").findOne({
+      where: {
+        "oauth_type": this.SSO_TYPE_GOOGLE
+      }
+    });
+  },
+  async cognitoRoles() {
+    return await strapi2.query("plugin::strapi-plugin-sso.roles").findOne({
+      where: {
+        "oauth_type": this.SSO_TYPE_COGNITO
+      }
+    });
+  },
+  async azureAdRoles() {
+    return await strapi2.query("plugin::strapi-plugin-sso.roles").findOne({
+      where: {
+        oauth_type: this.SSO_TYPE_AZUREAD
+      }
+    });
+  },
+  async oidcRoles() {
+    return await strapi2.query("plugin::strapi-plugin-sso.roles").findOne({
+      where: {
+        "oauth_type": this.SSO_TYPE_OIDC
+      }
+    });
+  },
+  async find() {
+    return await strapi2.query("plugin::strapi-plugin-sso.roles").findMany();
+  },
+  async update(roles2) {
+    const query = strapi2.query("plugin::strapi-plugin-sso.roles");
+    await Promise.all(
+      roles2.map((role2) => {
+        return query.findOne({ where: { "oauth_type": role2["oauth_type"] } }).then((ssoRole) => {
+          if (ssoRole) {
+            query.update({
+              where: { "oauth_type": role2["oauth_type"] },
+              data: { roles: role2.role }
+            });
+          } else {
+            query.create({
+              data: {
+                "oauth_type": role2["oauth_type"],
+                roles: role2.role
+              }
+            });
+          }
+        });
+      })
+    );
+  }
+});
+const whitelist = ({ strapi: strapi2 }) => ({
+  async getUsers() {
+    const query = strapi2.query("plugin::strapi-plugin-sso.whitelists");
+    return await query.findMany();
+  },
+  async registerUser(email) {
+    const query = strapi2.query("plugin::strapi-plugin-sso.whitelists");
+    await query.create({
+      data: {
+        email: email.toLowerCase()
+      }
+    });
+  },
+  async removeUser(id) {
+    const query = strapi2.query("plugin::strapi-plugin-sso.whitelists");
+    await query.delete({
+      where: {
+        id
+      }
+    });
+  },
+  async checkWhitelistForEmail(email) {
+    const config2 = strapi2.config.get("plugin::strapi-plugin-sso");
+    const useWhitelist = config2["USE_WHITELIST"] === true;
+    if (!useWhitelist) {
+      return;
+    }
+    const query = strapi2.query("plugin::strapi-plugin-sso.whitelists");
+    const result = await query.findOne({
+      where: {
+        email: email.toLowerCase()
+      }
+    });
+    if (result === null) {
+      throw new Error("Not present in whitelist");
+    }
+  }
+});
+const services = {
+  oauth,
+  role,
+  whitelist
+};
+const index = {
+  register: register$1,
+  bootstrap,
+  destroy,
+  config,
+  controllers,
+  routes,
+  services,
+  contentTypes,
+  policies
+};
+module.exports = index;

--- a/dist/server/index.mjs
+++ b/dist/server/index.mjs
@@ -1,0 +1,997 @@
+import axios from "axios";
+import { Buffer } from "buffer";
+import { randomUUID, getRandomValues } from "node:crypto";
+import pkceChallenge from "pkce-challenge";
+import strapiUtils from "@strapi/utils";
+import generator from "generate-password";
+const register$1 = ({ strapi: strapi2 }) => {
+};
+const bootstrap = async ({ strapi: strapi2 }) => {
+  const actions = [
+    {
+      section: "plugins",
+      displayName: "Read",
+      uid: "read",
+      pluginName: "strapi-plugin-sso"
+    }
+  ];
+  await strapi2.admin.services.permission.actionProvider.registerMany(actions);
+};
+const destroy = ({ strapi: strapi2 }) => {
+};
+const config = {
+  default: {
+    REMEMBER_ME: false,
+    GOOGLE_OAUTH_REDIRECT_URI: "http://localhost:1337/strapi-plugin-sso/google/callback",
+    GOOGLE_GSUITE_HD: "",
+    GOOGLE_ALIAS: "",
+    COGNITO_OAUTH_REDIRECT_URI: "http://localhost:1337/strapi-plugin-sso/cognito/callback",
+    COGNITO_OAUTH_REGION: "ap-northeast-1",
+    AZUREAD_OAUTH_REDIRECT_URI: "http://localhost:1337/strapi-plugin-sso/azuread/callback",
+    AZUREAD_TENANT_ID: "",
+    AZUREAD_OAUTH_CLIENT_ID: "",
+    AZUREAD_OAUTH_CLIENT_SECRET: "",
+    AZUREAD_SCOPE: "user.read",
+    OIDC_REDIRECT_URI: "http://localhost:1337/strapi-plugin-sso/oidc/callback",
+    OIDC_CLIENT_ID: "",
+    OIDC_CLIENT_SECRET: "",
+    OIDC_SCOPES: "openid profile email",
+    OIDC_AUTHORIZATION_ENDPOINT: "",
+    OIDC_TOKEN_ENDPOINT: "",
+    OIDC_USER_INFO_ENDPOINT: "",
+    OIDC_USER_INFO_ENDPOINT_WITH_AUTH_HEADER: false,
+    OIDC_GRANT_TYPE: "authorization_code",
+    OIDC_FAMILY_NAME_FIELD: "family_name",
+    OIDC_GIVEN_NAME_FIELD: "given_name"
+  },
+  validator() {
+  }
+};
+const info$2 = {
+  singularName: "roles",
+  pluralName: "sso-roles",
+  collectionName: "sso-roles",
+  displayName: "sso-role",
+  description: ""
+};
+const options$1 = {
+  draftAndPublish: false
+};
+const pluginOptions$1 = {
+  "content-manager": {
+    visible: false
+  },
+  "content-type-builder": {
+    visible: false
+  }
+};
+const attributes$1 = {
+  oauth_type: {
+    type: "string",
+    configurable: false,
+    required: true
+  },
+  roles: {
+    type: "json",
+    configurable: false
+  }
+};
+const schema$1 = {
+  info: info$2,
+  options: options$1,
+  pluginOptions: pluginOptions$1,
+  attributes: attributes$1
+};
+const roles = {
+  schema: schema$1
+};
+const info$1 = {
+  singularName: "whitelists",
+  pluralName: "whitelists",
+  collectionName: "whitelists",
+  displayName: "whitelist",
+  description: ""
+};
+const options = {
+  draftAndPublish: false
+};
+const pluginOptions = {
+  "content-manager": {
+    visible: false
+  },
+  "content-type-builder": {
+    visible: false
+  }
+};
+const attributes = {
+  email: {
+    type: "string",
+    configurable: false,
+    required: true,
+    unique: true
+  }
+};
+const schema = {
+  info: info$1,
+  options,
+  pluginOptions,
+  attributes
+};
+const whitelists = {
+  schema
+};
+const contentTypes = {
+  roles,
+  whitelists
+};
+const configValidation$3 = () => {
+  const config2 = strapi.config.get("plugin::strapi-plugin-sso");
+  if (config2["GOOGLE_OAUTH_CLIENT_ID"] && config2["GOOGLE_OAUTH_CLIENT_SECRET"]) {
+    return config2;
+  }
+  throw new Error("GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET are required");
+};
+const OAUTH_ENDPOINT$2 = "https://accounts.google.com/o/oauth2/auth";
+const OAUTH_TOKEN_ENDPOINT$2 = "https://accounts.google.com/o/oauth2/token";
+const OAUTH_USER_INFO_ENDPOINT$2 = "https://www.googleapis.com/oauth2/v1/userinfo";
+const OAUTH_GRANT_TYPE$2 = "authorization_code";
+const OAUTH_RESPONSE_TYPE$2 = "code";
+const OAUTH_SCOPE$1 = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile";
+async function googleSignIn(ctx) {
+  const config2 = configValidation$3();
+  const { code_verifier: codeVerifier, code_challenge: codeChallenge } = pkceChallenge();
+  ctx.session.codeVerifier = codeVerifier;
+  const state = getRandomValues(Buffer.alloc(32)).toString("base64url");
+  ctx.session.oidcState = state;
+  const params = new URLSearchParams();
+  params.append("client_id", config2["GOOGLE_OAUTH_CLIENT_ID"]);
+  params.append("redirect_uri", config2["GOOGLE_OAUTH_REDIRECT_URI"]);
+  params.append("scope", OAUTH_SCOPE$1);
+  params.append("response_type", OAUTH_RESPONSE_TYPE$2);
+  params.append("code_challenge", codeChallenge);
+  params.append("code_challenge_method", "S256");
+  params.append("state", state);
+  const url = `${OAUTH_ENDPOINT$2}?${params.toString()}`;
+  ctx.set("Location", url);
+  return ctx.send({}, 302);
+}
+async function googleSignInCallback(ctx) {
+  const config2 = configValidation$3();
+  const httpClient = axios.create();
+  const userService = strapi.service("admin::user");
+  const oauthService = strapi.plugin("strapi-plugin-sso").service("oauth");
+  const roleService = strapi.plugin("strapi-plugin-sso").service("role");
+  const whitelistService = strapi.plugin("strapi-plugin-sso").service("whitelist");
+  if (!ctx.query.code) {
+    return ctx.send(oauthService.renderSignUpError(`code Not Found`));
+  }
+  if (!ctx.query.state || ctx.query.state !== ctx.session.oidcState) {
+    return ctx.send(oauthService.renderSignUpError(`Invalid state`));
+  }
+  const params = new URLSearchParams();
+  params.append("code", ctx.query.code);
+  params.append("client_id", config2["GOOGLE_OAUTH_CLIENT_ID"]);
+  params.append("client_secret", config2["GOOGLE_OAUTH_CLIENT_SECRET"]);
+  params.append("redirect_uri", config2["GOOGLE_OAUTH_REDIRECT_URI"]);
+  params.append("grant_type", OAUTH_GRANT_TYPE$2);
+  params.append("code_verifier", ctx.session.codeVerifier);
+  try {
+    const response = await httpClient.post(OAUTH_TOKEN_ENDPOINT$2, params, {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      }
+    });
+    const userInfoEndpoint = `${OAUTH_USER_INFO_ENDPOINT$2}?access_token=${response.data.access_token}`;
+    const userResponse = await httpClient.get(userInfoEndpoint);
+    if (config2["GOOGLE_GSUITE_HD"]) {
+      if (userResponse.data.hd !== config2["GOOGLE_GSUITE_HD"]) {
+        throw new Error("Unauthorized email address");
+      }
+    }
+    const email = config2["GOOGLE_ALIAS"] ? oauthService.addGmailAlias(userResponse.data.email, config2["GOOGLE_ALIAS"]) : userResponse.data.email;
+    await whitelistService.checkWhitelistForEmail(email);
+    const dbUser = await userService.findOneByEmail(email);
+    let activateUser;
+    let jwtToken;
+    if (dbUser) {
+      activateUser = dbUser;
+      jwtToken = await oauthService.generateToken(dbUser, ctx);
+    } else {
+      const googleRoles = await roleService.googleRoles();
+      const roles2 = googleRoles && googleRoles["roles"] ? googleRoles["roles"].map((role2) => ({
+        id: role2
+      })) : [];
+      const defaultLocale = oauthService.localeFindByHeader(ctx.request.headers);
+      activateUser = await oauthService.createUser(
+        email,
+        userResponse.data.family_name,
+        userResponse.data.given_name,
+        defaultLocale,
+        roles2
+      );
+      jwtToken = await oauthService.generateToken(activateUser, ctx);
+      await oauthService.triggerWebHook(activateUser);
+    }
+    oauthService.triggerSignInSuccess(activateUser);
+    const nonce = randomUUID();
+    const html = oauthService.renderSignUpSuccess(jwtToken, activateUser, nonce);
+    ctx.set("Content-Security-Policy", `script-src 'nonce-${nonce}'`);
+    ctx.send(html);
+  } catch (e) {
+    console.error(e);
+    ctx.send(oauthService.renderSignUpError(e.message));
+  }
+}
+const google = {
+  googleSignIn,
+  googleSignInCallback
+};
+const configValidation$2 = () => {
+  const config2 = strapi.config.get("plugin::strapi-plugin-sso");
+  if (config2["COGNITO_OAUTH_CLIENT_ID"] && config2["COGNITO_OAUTH_CLIENT_SECRET"] && config2["COGNITO_OAUTH_DOMAIN"]) {
+    return config2;
+  }
+  throw new Error("COGNITO_OAUTH_CLIENT_ID, COGNITO_OAUTH_CLIENT_SECRET AND COGNITO_OAUTH_DOMAIN are required");
+};
+const OAUTH_ENDPOINT$1 = (domain, region) => {
+  return `https://${domain}.auth.${region}.amazoncognito.com/oauth2/authorize`;
+};
+const OAUTH_TOKEN_ENDPOINT$1 = (domain, region) => {
+  return `https://${domain}.auth.${region}.amazoncognito.com/oauth2/token`;
+};
+const OAUTH_USER_INFO_ENDPOINT$1 = (domain, region) => {
+  return `https://${domain}.auth.${region}.amazoncognito.com/oauth2/userInfo`;
+};
+const OAUTH_GRANT_TYPE$1 = "authorization_code";
+const OAUTH_SCOPE = "openid email profile";
+const OAUTH_RESPONSE_TYPE$1 = "code";
+async function cognitoSignIn(ctx) {
+  const config2 = configValidation$2();
+  const endpoint = OAUTH_ENDPOINT$1(config2["COGNITO_OAUTH_DOMAIN"], config2["COGNITO_OAUTH_REGION"]);
+  const { code_verifier: codeVerifier, code_challenge: codeChallenge } = pkceChallenge();
+  ctx.session.codeVerifier = codeVerifier;
+  const state = getRandomValues(Buffer.alloc(32)).toString("base64url");
+  ctx.session.oidcState = state;
+  const params = new URLSearchParams();
+  params.append("client_id", config2["COGNITO_OAUTH_CLIENT_ID"]);
+  params.append("redirect_uri", config2["COGNITO_OAUTH_REDIRECT_URI"]);
+  params.append("scope", OAUTH_SCOPE);
+  params.append("response_type", OAUTH_RESPONSE_TYPE$1);
+  params.append("code_challenge", codeChallenge);
+  params.append("code_challenge_method", "S256");
+  params.append("state", state);
+  const url = `${endpoint}?${params.toString()}`;
+  ctx.set("Location", url);
+  return ctx.send({}, 302);
+}
+async function cognitoSignInCallback(ctx) {
+  const config2 = configValidation$2();
+  const userService = strapi.service("admin::user");
+  const oauthService = strapi.plugin("strapi-plugin-sso").service("oauth");
+  const roleService = strapi.plugin("strapi-plugin-sso").service("role");
+  const whitelistService = strapi.plugin("strapi-plugin-sso").service("whitelist");
+  if (!ctx.query.code) {
+    return ctx.send(oauthService.renderSignUpError(`code Not Found`));
+  }
+  if (!ctx.query.state || ctx.query.state !== ctx.session.oidcState) {
+    return ctx.send(oauthService.renderSignUpError(`Invalid state`));
+  }
+  const params = new URLSearchParams();
+  params.append("code", ctx.query.code);
+  params.append("client_id", config2["COGNITO_OAUTH_CLIENT_ID"]);
+  params.append("client_secret", config2["COGNITO_OAUTH_CLIENT_SECRET"]);
+  params.append("redirect_uri", config2["COGNITO_OAUTH_REDIRECT_URI"]);
+  params.append("grant_type", OAUTH_GRANT_TYPE$1);
+  params.append("code_verifier", ctx.session.codeVerifier);
+  try {
+    const tokenEndpoint = OAUTH_TOKEN_ENDPOINT$1(config2["COGNITO_OAUTH_DOMAIN"], config2["COGNITO_OAUTH_REGION"]);
+    const userInfoEndpoint = OAUTH_USER_INFO_ENDPOINT$1(config2["COGNITO_OAUTH_DOMAIN"], config2["COGNITO_OAUTH_REGION"]);
+    const response = await axios.post(tokenEndpoint, params, {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      }
+    });
+    const userResponse = await axios.get(userInfoEndpoint, {
+      headers: {
+        Authorization: `Bearer ${response.data.access_token}`
+      }
+    });
+    if (userResponse.data.email_verified !== "true") {
+      throw new Error("Your email address has not been verified.");
+    }
+    const userGroup = config2["COGNITO_USER_GROUP"];
+    if (userGroup) {
+      const claims = JSON.parse(Buffer.from(response.data.access_token.split(".")[1], "base64").toString());
+      if ((claims["cognito:groups"] || []).includes(userGroup) === false) {
+        throw new Error("You do not belong to the specified user group.");
+      }
+    }
+    await whitelistService.checkWhitelistForEmail(userResponse.data.email);
+    const dbUser = await userService.findOneByEmail(userResponse.data.email);
+    let activateUser;
+    let jwtToken;
+    if (dbUser) {
+      activateUser = dbUser;
+      jwtToken = await oauthService.generateToken(dbUser, ctx);
+    } else {
+      const cognitoRoles = await roleService.cognitoRoles();
+      const roles2 = cognitoRoles && cognitoRoles["roles"] ? cognitoRoles["roles"].map((role2) => ({
+        id: role2
+      })) : [];
+      const defaultLocale = oauthService.localeFindByHeader(ctx.request.headers);
+      activateUser = await oauthService.createUser(
+        userResponse.data.email,
+        "",
+        userResponse.data.username,
+        defaultLocale,
+        roles2
+      );
+      jwtToken = await oauthService.generateToken(activateUser, ctx);
+      await oauthService.triggerWebHook(activateUser);
+    }
+    oauthService.triggerSignInSuccess(activateUser);
+    const nonce = randomUUID();
+    const html = oauthService.renderSignUpSuccess(jwtToken, activateUser, nonce);
+    ctx.set("Content-Security-Policy", `script-src 'nonce-${nonce}'`);
+    ctx.send(html);
+  } catch (e) {
+    console.error(e);
+    ctx.send(oauthService.renderSignUpError(e.message));
+  }
+}
+const cognito = {
+  cognitoSignIn,
+  cognitoSignInCallback
+};
+const configValidation$1 = () => {
+  const config2 = strapi.config.get("plugin::strapi-plugin-sso");
+  if (config2["AZUREAD_OAUTH_CLIENT_ID"] && config2["AZUREAD_OAUTH_CLIENT_SECRET"] && config2["AZUREAD_TENANT_ID"]) {
+    return config2;
+  }
+  throw new Error(
+    "AZUREAD_OAUTH_CLIENT_ID, AZUREAD_OAUTH_CLIENT_SECRET, and AZUREAD_TENANT_ID are required"
+  );
+};
+const OAUTH_ENDPOINT = (tenantId) => `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/authorize`;
+const OAUTH_TOKEN_ENDPOINT = (tenantId) => `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
+const OAUTH_USER_INFO_ENDPOINT = "https://graph.microsoft.com/oidc/userinfo";
+const OAUTH_GRANT_TYPE = "authorization_code";
+const OAUTH_RESPONSE_TYPE = "code";
+async function azureAdSignIn(ctx) {
+  const config2 = configValidation$1();
+  const endpoint = OAUTH_ENDPOINT(config2["AZUREAD_TENANT_ID"]);
+  const { code_verifier: codeVerifier, code_challenge: codeChallenge } = pkceChallenge();
+  ctx.session.codeVerifier = codeVerifier;
+  const state = getRandomValues(Buffer.alloc(32)).toString("base64url");
+  ctx.session.oidcState = state;
+  const params = new URLSearchParams();
+  params.append("client_id", config2["AZUREAD_OAUTH_CLIENT_ID"]);
+  params.append("redirect_uri", config2["AZUREAD_OAUTH_REDIRECT_URI"]);
+  params.append("scope", config2["AZUREAD_SCOPE"]);
+  params.append("response_type", OAUTH_RESPONSE_TYPE);
+  params.append("code_challenge", codeChallenge);
+  params.append("code_challenge_method", "S256");
+  params.append("state", state);
+  const url = `${endpoint}?${params.toString()}`;
+  ctx.set("Location", url);
+  return ctx.send({}, 302);
+}
+async function azureAdSignInCallback(ctx) {
+  const config2 = configValidation$1();
+  const userService = strapi.service("admin::user");
+  const oauthService = strapi.plugin("strapi-plugin-sso").service("oauth");
+  const roleService = strapi.plugin("strapi-plugin-sso").service("role");
+  const whitelistService = strapi.plugin("strapi-plugin-sso").service("whitelist");
+  if (!ctx.query.code) {
+    return ctx.send(oauthService.renderSignUpError(`code Not Found`));
+  }
+  if (!ctx.query.state || ctx.query.state !== ctx.session.oidcState) {
+    return ctx.send(oauthService.renderSignUpError(`Invalid state`));
+  }
+  const params = new URLSearchParams();
+  params.append("code", ctx.query.code);
+  params.append("client_id", config2["AZUREAD_OAUTH_CLIENT_ID"]);
+  params.append("client_secret", config2["AZUREAD_OAUTH_CLIENT_SECRET"]);
+  params.append("redirect_uri", config2["AZUREAD_OAUTH_REDIRECT_URI"]);
+  params.append("grant_type", OAUTH_GRANT_TYPE);
+  params.append("code_verifier", ctx.session.codeVerifier);
+  try {
+    const tokenEndpoint = OAUTH_TOKEN_ENDPOINT(config2["AZUREAD_TENANT_ID"]);
+    const response = await axios.post(tokenEndpoint, params, {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      }
+    });
+    const userResponse = await axios.get(OAUTH_USER_INFO_ENDPOINT, {
+      headers: {
+        Authorization: `Bearer ${response.data.access_token}`
+      }
+    });
+    if (!userResponse.data.email) {
+      throw new Error("Email address is not set. Please set email property to the Azure AD user.");
+    }
+    await whitelistService.checkWhitelistForEmail(userResponse.data.email);
+    const dbUser = await userService.findOneByEmail(userResponse.data.email);
+    let activateUser;
+    let jwtToken;
+    if (dbUser) {
+      activateUser = dbUser;
+      jwtToken = await oauthService.generateToken(dbUser, ctx);
+    } else {
+      const azureAdRoles = await roleService.azureAdRoles();
+      const roles2 = azureAdRoles && azureAdRoles["roles"] ? azureAdRoles["roles"].map((role2) => ({
+        id: role2
+      })) : [];
+      const defaultLocale = oauthService.localeFindByHeader(
+        ctx.request.headers
+      );
+      activateUser = await oauthService.createUser(
+        userResponse.data.email,
+        userResponse.data.family_name,
+        userResponse.data.given_name,
+        defaultLocale,
+        roles2
+      );
+      jwtToken = await oauthService.generateToken(activateUser, ctx);
+      await oauthService.triggerWebHook(activateUser);
+    }
+    oauthService.triggerSignInSuccess(activateUser);
+    const nonce = randomUUID();
+    const html = oauthService.renderSignUpSuccess(
+      jwtToken,
+      activateUser,
+      nonce
+    );
+    ctx.set("Content-Security-Policy", `script-src 'nonce-${nonce}'`);
+    ctx.send(html);
+  } catch (e) {
+    console.error(e);
+    ctx.send(oauthService.renderSignUpError(e.message));
+  }
+}
+const azuread = {
+  azureAdSignIn,
+  azureAdSignInCallback
+};
+const configValidation = () => {
+  const config2 = strapi.config.get("plugin::strapi-plugin-sso");
+  if (config2["OIDC_CLIENT_ID"] && config2["OIDC_CLIENT_SECRET"] && config2["OIDC_REDIRECT_URI"] && config2["OIDC_SCOPES"] && config2["OIDC_TOKEN_ENDPOINT"] && config2["OIDC_USER_INFO_ENDPOINT"] && config2["OIDC_GRANT_TYPE"] && config2["OIDC_FAMILY_NAME_FIELD"] && config2["OIDC_GIVEN_NAME_FIELD"] && config2["OIDC_AUTHORIZATION_ENDPOINT"]) {
+    return config2;
+  }
+  throw new Error("OIDC_AUTHORIZATION_ENDPOINT,OIDC_TOKEN_ENDPOINT, OIDC_USER_INFO_ENDPOINT,OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_REDIRECT_URI, and OIDC_SCOPES are required");
+};
+const oidcSignIn = async (ctx) => {
+  let { state } = ctx.query;
+  const { OIDC_CLIENT_ID, OIDC_REDIRECT_URI, OIDC_SCOPES, OIDC_AUTHORIZATION_ENDPOINT } = configValidation();
+  const { code_verifier: codeVerifier, code_challenge: codeChallenge } = pkceChallenge();
+  ctx.session.codeVerifier = codeVerifier;
+  if (!state) {
+    state = getRandomValues(Buffer.alloc(32)).toString("base64url");
+  }
+  ctx.session.oidcState = state;
+  const params = new URLSearchParams();
+  params.append("response_type", "code");
+  params.append("client_id", OIDC_CLIENT_ID);
+  params.append("redirect_uri", OIDC_REDIRECT_URI);
+  params.append("scope", OIDC_SCOPES);
+  params.append("code_challenge", codeChallenge);
+  params.append("code_challenge_method", "S256");
+  params.append("state", state);
+  const authorizationUrl = `${OIDC_AUTHORIZATION_ENDPOINT}?${params.toString()}`;
+  ctx.set("Location", authorizationUrl);
+  return ctx.send({}, 302);
+};
+const oidcSignInCallback = async (ctx) => {
+  const config2 = configValidation();
+  const httpClient = axios.create();
+  const userService = strapi.service("admin::user");
+  const oauthService = strapi.plugin("strapi-plugin-sso").service("oauth");
+  const roleService = strapi.plugin("strapi-plugin-sso").service("role");
+  const whitelistService = strapi.plugin("strapi-plugin-sso").service("whitelist");
+  if (!ctx.query.code) {
+    return ctx.send(oauthService.renderSignUpError(`code Not Found`));
+  }
+  if (!ctx.query.state || ctx.query.state !== ctx.session.oidcState) {
+    return ctx.send(oauthService.renderSignUpError(`Invalid state`));
+  }
+  const params = new URLSearchParams();
+  params.append("code", ctx.query.code);
+  params.append("client_id", config2["OIDC_CLIENT_ID"]);
+  params.append("client_secret", config2["OIDC_CLIENT_SECRET"]);
+  params.append("redirect_uri", config2["OIDC_REDIRECT_URI"]);
+  params.append("grant_type", config2["OIDC_GRANT_TYPE"]);
+  params.append("code_verifier", ctx.session.codeVerifier);
+  try {
+    const response = await httpClient.post(config2["OIDC_TOKEN_ENDPOINT"], params, {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      }
+    });
+    let userInfoEndpointHeaders = {};
+    let userInfoEndpointParameters = `?access_token=${response.data.access_token}`;
+    if (config2["OIDC_USER_INFO_ENDPOINT_WITH_AUTH_HEADER"]) {
+      userInfoEndpointHeaders = {
+        headers: { Authorization: `Bearer ${response.data.access_token}` }
+      };
+      userInfoEndpointParameters = "";
+    }
+    const userInfoEndpoint = `${config2["OIDC_USER_INFO_ENDPOINT"]}${userInfoEndpointParameters}`;
+    const userResponse = await httpClient.get(
+      userInfoEndpoint,
+      userInfoEndpointHeaders
+    );
+    const email = userResponse.data.email;
+    await whitelistService.checkWhitelistForEmail(email);
+    const dbUser = await userService.findOneByEmail(email);
+    let activateUser;
+    let jwtToken;
+    if (dbUser) {
+      activateUser = dbUser;
+      jwtToken = await oauthService.generateToken(dbUser, ctx);
+    } else {
+      const oidcRoles = await roleService.oidcRoles();
+      const roles2 = oidcRoles && oidcRoles["roles"] ? oidcRoles["roles"].map((role2) => ({
+        id: role2
+      })) : [];
+      const defaultLocale = oauthService.localeFindByHeader(ctx.request.headers);
+      activateUser = await oauthService.createUser(
+        email,
+        userResponse.data[config2["OIDC_FAMILY_NAME_FIELD"]],
+        userResponse.data[config2["OIDC_GIVEN_NAME_FIELD"]],
+        defaultLocale,
+        roles2
+      );
+      jwtToken = await oauthService.generateToken(activateUser, ctx);
+      await oauthService.triggerWebHook(activateUser);
+    }
+    oauthService.triggerSignInSuccess(activateUser);
+    const nonce = randomUUID();
+    const html = oauthService.renderSignUpSuccess(jwtToken, activateUser, nonce);
+    ctx.set("Content-Security-Policy", `script-src 'nonce-${nonce}'`);
+    ctx.send(html);
+  } catch (e) {
+    console.error(e);
+    ctx.send(oauthService.renderSignUpError(e.message));
+  }
+};
+const oidc = {
+  oidcSignIn,
+  oidcSignInCallback
+};
+async function find(ctx) {
+  const roleService = strapi.plugin("strapi-plugin-sso").service("role");
+  const roles2 = await roleService.find();
+  const ssoConstants = roleService.ssoRoles();
+  for (const sso of ssoConstants) {
+    for (const role2 of roles2) {
+      if (role2["oauth_type"] === sso["oauth_type"]) {
+        sso["role"] = role2["roles"];
+      }
+    }
+  }
+  ctx.send(ssoConstants);
+}
+async function update(ctx) {
+  try {
+    const { roles: roles2 } = ctx.request.body;
+    const roleService = strapi.plugin("strapi-plugin-sso").service("role");
+    await roleService.update(roles2);
+    ctx.send({}, 204);
+  } catch (e) {
+    console.log(e);
+    ctx.send({}, 400);
+  }
+}
+const role$1 = {
+  find,
+  update
+};
+async function info(ctx) {
+  const config2 = strapi.config.get("plugin::strapi-plugin-sso");
+  const useWhitelist = config2["USE_WHITELIST"] === true;
+  let whitelistUsers = [];
+  const whitelistService = strapi.plugin("strapi-plugin-sso").service("whitelist");
+  whitelistUsers = await whitelistService.getUsers();
+  ctx.body = {
+    useWhitelist,
+    whitelistUsers
+  };
+}
+async function register(ctx) {
+  const { email } = ctx.request.body;
+  if (!email) {
+    ctx.body = {
+      message: "Please enter a valid email address"
+    };
+  }
+  const whitelistService = strapi.plugin("strapi-plugin-sso").service("whitelist");
+  await whitelistService.registerUser(email);
+  ctx.body = {};
+}
+async function removeEmail(ctx) {
+  const { id } = ctx.params;
+  const whitelistService = strapi.plugin("strapi-plugin-sso").service("whitelist");
+  await whitelistService.removeUser(id);
+  ctx.body = {};
+}
+const whitelist$1 = {
+  info,
+  register,
+  removeEmail
+};
+const controllers = {
+  google,
+  cognito,
+  azuread,
+  oidc,
+  role: role$1,
+  whitelist: whitelist$1
+};
+const routes = [
+  {
+    method: "GET",
+    path: "/google",
+    handler: "google.googleSignIn",
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: "GET",
+    path: "/google/callback",
+    handler: "google.googleSignInCallback",
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: "GET",
+    path: "/cognito",
+    handler: "cognito.cognitoSignIn",
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: "GET",
+    path: "/cognito/callback",
+    handler: "cognito.cognitoSignInCallback",
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: "GET",
+    path: "/azuread",
+    handler: "azuread.azureAdSignIn",
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: "GET",
+    path: "/azuread/callback",
+    handler: "azuread.azureAdSignInCallback",
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: "GET",
+    path: "/sso-roles",
+    handler: "role.find"
+  },
+  {
+    method: "PUT",
+    path: "/sso-roles",
+    handler: "role.update"
+  },
+  {
+    method: "GET",
+    path: "/oidc",
+    handler: "oidc.oidcSignIn",
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: "GET",
+    path: "/oidc/callback",
+    handler: "oidc.oidcSignInCallback",
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: "GET",
+    path: "/whitelist",
+    handler: "whitelist.info"
+  },
+  {
+    method: "POST",
+    path: "/whitelist",
+    handler: "whitelist.register"
+  },
+  {
+    method: "DELETE",
+    path: "/whitelist/:id",
+    handler: "whitelist.removeEmail"
+  }
+];
+const policies = {};
+const oauth = ({ strapi: strapi2 }) => ({
+  async createUser(email, lastname, firstname, locale, roles2 = []) {
+    const userService = strapi2.service("admin::user");
+    if (/[A-Z]/.test(email)) {
+      const dbUser = await userService.findOneByEmail(email.toLocaleLowerCase());
+      if (dbUser) {
+        return dbUser;
+      }
+    }
+    const createdUser = await userService.create({
+      firstname: firstname ? firstname : "unset",
+      lastname: lastname ? lastname : "",
+      email: email.toLocaleLowerCase(),
+      roles: roles2,
+      preferedLanguage: locale
+    });
+    return await userService.register({
+      registrationToken: createdUser.registrationToken,
+      userInfo: {
+        firstname: firstname ? firstname : "unset",
+        lastname: lastname ? lastname : "user",
+        password: generator.generate({
+          length: 43,
+          // 256 bits (https://en.wikipedia.org/wiki/Password_strength#Random_passwords)
+          numbers: true,
+          lowercase: true,
+          uppercase: true,
+          exclude: '()+_-=}{[]|:;"/?.><,`~',
+          strict: true
+        })
+      }
+    });
+  },
+  addGmailAlias(baseEmail, baseAlias) {
+    if (!baseAlias) {
+      return baseEmail;
+    }
+    const alias = baseAlias.replace("/+/g", "");
+    const beforePosition = baseEmail.indexOf("@");
+    const origin = baseEmail.substring(0, beforePosition);
+    const domain = baseEmail.substring(beforePosition);
+    return `${origin}+${alias}${domain}`;
+  },
+  localeFindByHeader(headers) {
+    if (headers["accept-language"] && headers["accept-language"].includes("ja")) {
+      return "ja";
+    } else {
+      return "en";
+    }
+  },
+  async triggerWebHook(user) {
+    let ENTRY_CREATE;
+    const webhookStore = strapi2.serviceMap.get("webhookStore");
+    const eventHub = strapi2.serviceMap.get("eventHub");
+    if (webhookStore) {
+      ENTRY_CREATE = webhookStore.allowedEvents.get("ENTRY_CREATE");
+    }
+    const modelDef = strapi2.getModel("admin::user");
+    const sanitizedEntity = await strapiUtils.sanitize.sanitizers.defaultSanitizeOutput({
+      schema: modelDef,
+      getModel: (uid2) => strapi2.getModel(uid2)
+    }, user);
+    eventHub.emit(ENTRY_CREATE, {
+      model: modelDef.modelName,
+      entry: sanitizedEntity
+    });
+  },
+  triggerSignInSuccess(user) {
+    delete user["password"];
+    const eventHub = strapi2.serviceMap.get("eventHub");
+    eventHub.emit("admin.auth.success", {
+      user,
+      provider: "strapi-plugin-sso"
+    });
+  },
+  // Sign In Success
+  renderSignUpSuccess(jwtToken, user, nonce) {
+    const config2 = strapi2.config.get("plugin::strapi-plugin-sso");
+    const REMEMBER_ME = config2["REMEMBER_ME"];
+    const isRememberMe = !!REMEMBER_ME;
+    return `
+<!doctype html>
+<html>
+<head>
+<noscript>
+<h3>JavaScript must be enabled for authentication</h3>
+</noscript>
+<script nonce="${nonce}">
+ window.addEventListener('load', function() {
+  if(${isRememberMe}){
+    localStorage.setItem('jwtToken', '"${jwtToken}"');
+  }else{
+    document.cookie = 'jwtToken=${encodeURIComponent(jwtToken)}; Path=/';
+  }
+  localStorage.setItem('isLoggedIn', 'true');
+  location.href = '${strapi2.config.admin.url}'
+ })
+<\/script>
+</head>
+<body>
+</body>
+</html>`;
+  },
+  // Sign In Error
+  renderSignUpError(message) {
+    return `
+<!doctype html>
+<html>
+<head></head>
+<body>
+<h3>Authentication failed</h3>
+<p>${message}</p>
+</body>
+</html>`;
+  },
+  async generateToken(user, ctx) {
+    const sessionManager = strapi2.sessionManager;
+    if (!sessionManager) {
+      throw new Error("sessionManager is not supported. Please upgrade to Strapi v5.24.1 or later.");
+    }
+    const userId = String(user.id);
+    const deviceId = randomUUID();
+    const config2 = strapi2.config.get("plugin::strapi-plugin-sso");
+    const REMEMBER_ME = config2["REMEMBER_ME"];
+    const rememberMe = !!REMEMBER_ME;
+    const { token: refreshToken } = await sessionManager(
+      "admin"
+    ).generateRefreshToken(userId, deviceId, {
+      type: rememberMe ? "refresh" : "session"
+    });
+    const cookieOptions = {};
+    ctx.cookies.set("strapi_admin_refresh", refreshToken, cookieOptions);
+    const accessResult = await sessionManager("admin").generateAccessToken(refreshToken);
+    if ("error" in accessResult) {
+      throw new Error(accessResult.error);
+    }
+    const { token: accessToken } = accessResult;
+    return accessToken;
+  }
+});
+const role = ({ strapi: strapi2 }) => ({
+  SSO_TYPE_GOOGLE: "1",
+  SSO_TYPE_COGNITO: "2",
+  SSO_TYPE_AZUREAD: "3",
+  SSO_TYPE_OIDC: "4",
+  ssoRoles() {
+    return [
+      {
+        "oauth_type": this.SSO_TYPE_GOOGLE,
+        name: "Google"
+      },
+      {
+        "oauth_type": this.SSO_TYPE_COGNITO,
+        name: "Cognito"
+      },
+      {
+        "oauth_type": this.SSO_TYPE_AZUREAD,
+        name: "AzureAD"
+      },
+      {
+        "oauth_type": this.SSO_TYPE_OIDC,
+        name: "OIDC"
+      }
+    ];
+  },
+  async googleRoles() {
+    return await strapi2.query("plugin::strapi-plugin-sso.roles").findOne({
+      where: {
+        "oauth_type": this.SSO_TYPE_GOOGLE
+      }
+    });
+  },
+  async cognitoRoles() {
+    return await strapi2.query("plugin::strapi-plugin-sso.roles").findOne({
+      where: {
+        "oauth_type": this.SSO_TYPE_COGNITO
+      }
+    });
+  },
+  async azureAdRoles() {
+    return await strapi2.query("plugin::strapi-plugin-sso.roles").findOne({
+      where: {
+        oauth_type: this.SSO_TYPE_AZUREAD
+      }
+    });
+  },
+  async oidcRoles() {
+    return await strapi2.query("plugin::strapi-plugin-sso.roles").findOne({
+      where: {
+        "oauth_type": this.SSO_TYPE_OIDC
+      }
+    });
+  },
+  async find() {
+    return await strapi2.query("plugin::strapi-plugin-sso.roles").findMany();
+  },
+  async update(roles2) {
+    const query = strapi2.query("plugin::strapi-plugin-sso.roles");
+    await Promise.all(
+      roles2.map((role2) => {
+        return query.findOne({ where: { "oauth_type": role2["oauth_type"] } }).then((ssoRole) => {
+          if (ssoRole) {
+            query.update({
+              where: { "oauth_type": role2["oauth_type"] },
+              data: { roles: role2.role }
+            });
+          } else {
+            query.create({
+              data: {
+                "oauth_type": role2["oauth_type"],
+                roles: role2.role
+              }
+            });
+          }
+        });
+      })
+    );
+  }
+});
+const whitelist = ({ strapi: strapi2 }) => ({
+  async getUsers() {
+    const query = strapi2.query("plugin::strapi-plugin-sso.whitelists");
+    return await query.findMany();
+  },
+  async registerUser(email) {
+    const query = strapi2.query("plugin::strapi-plugin-sso.whitelists");
+    await query.create({
+      data: {
+        email: email.toLowerCase()
+      }
+    });
+  },
+  async removeUser(id) {
+    const query = strapi2.query("plugin::strapi-plugin-sso.whitelists");
+    await query.delete({
+      where: {
+        id
+      }
+    });
+  },
+  async checkWhitelistForEmail(email) {
+    const config2 = strapi2.config.get("plugin::strapi-plugin-sso");
+    const useWhitelist = config2["USE_WHITELIST"] === true;
+    if (!useWhitelist) {
+      return;
+    }
+    const query = strapi2.query("plugin::strapi-plugin-sso.whitelists");
+    const result = await query.findOne({
+      where: {
+        email: email.toLowerCase()
+      }
+    });
+    if (result === null) {
+      throw new Error("Not present in whitelist");
+    }
+  }
+});
+const services = {
+  oauth,
+  role,
+  whitelist
+};
+const index = {
+  register: register$1,
+  bootstrap,
+  destroy,
+  config,
+  controllers,
+  routes,
+  services,
+  contentTypes,
+  policies
+};
+export {
+  index as default
+};

--- a/server/services/whitelist.js
+++ b/server/services/whitelist.js
@@ -7,7 +7,7 @@ export default ({strapi}) => ({
     const query = strapi.query('plugin::strapi-plugin-sso.whitelists')
     await query.create({
       data: {
-        email
+        email: email.toLowerCase()
       }
     })
   },
@@ -29,7 +29,7 @@ export default ({strapi}) => ({
     const query = strapi.query('plugin::strapi-plugin-sso.whitelists')
     const result = await query.findOne({
       where: {
-        email
+        email: email.toLowerCase()
       }
     })
     if (result === null) {


### PR DESCRIPTION
## Problem
Emails from OAuth providers (Azure AD, Google, Cognito, OIDC) may 
contain uppercase letters depending on the provider or user profile 
configuration. The whitelist lookup and registration used an exact 
string match, causing valid whitelisted users to be rejected when 
the case of their email differed from the stored entry.

For example, a user logging in with "John.Smith@Company.com" would 
fail the whitelist check if the stored entry was "john.smith@company.com".

## Fix
Call `email.toLowerCase()` in both "registerUser" and 
"checkWhitelistForEmail" in "server/services/whitelist.js". This 
ensures all storage and comparisons are case-insensitive regardless 
of what the OAuth provider returns.

The fix is in the service layer rather than individual controllers 
so it applies consistently across all providers (Azure AD, Google, 
Cognito, OIDC).